### PR TITLE
Keep GA cache only for main branch and re-use that everywhere else

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run cargo check
         run: |
@@ -43,6 +45,8 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run cargo fmt
         run: |
@@ -83,5 +87,7 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: pixi run --frozen cargo test --workspace --no-fail-fast


### PR DESCRIPTION
With duckDB plus tokio, the Rust cache was getting too large and forcing rollover on the cache quota and minimizing the impact of the cache. Let's hold the cache only for main, and each branch should have to recompile only the updates and new dependencies.