### PR TITLE
GHA update

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - crates/**
+      - Cargo.toml
+      - .github/workflows/ci-rust.yml
   schedule:
     - cron: '0 5 * * 1'
 


### PR DESCRIPTION
Following in the [footsteps of polars](https://github.com/pola-rs/polars/blob/c3a74601c70058c378fa36180b89b6795a6d7c14/.github/workflows/test-python.yml#L3-L19), we only run rust CI if rust-relevant files were updated. The only difference for our case compared to polars is that we do run rust CI always on push to main