### PR TITLE
No kwargs passed around in scripts

### DIFF
--- a/compass/_cli.py
+++ b/compass/_cli.py
@@ -32,7 +32,7 @@ def main(ctx):
     "-c",
     required=True,
     type=click.Path(exists=True),
-    help="Path to ordinance configuration JSON file. This file "
+    help="Path to ordinance configuration JSON or JSON5 file. This file "
     "should contain any/all the arguments to pass to "
     ":func:`compass.scripts.process.process_counties_with_openai`.",
 )

--- a/compass/extraction/apply.py
+++ b/compass/extraction/apply.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 async def check_for_ordinance_info(
     doc,
-    llm_parser_args,
+    llm_caller_args,
     heuristic,
     ordinance_text_collector_class,
     permitted_use_text_collector_class,
@@ -42,17 +42,6 @@ async def check_for_ordinance_info(
     usage_tracker : compass.services.usage.UsageTracker, optional
         Optional tracker instance to monitor token usage during
         LLM calls. By default, ``None``.
-    llm_parser_args : dict, optional
-        Keyword arguments to be passed to the llm service ``call``
-        method (i.e. `llm_service.call(**kwargs)`).
-        Should *not* contain the following keys:
-
-            - usage_tracker
-            - usage_sub_label
-            - messages
-
-        These arguments are provided by this caller object. By default,
-        ``None``.
 
     Returns
     -------
@@ -72,11 +61,11 @@ async def check_for_ordinance_info(
         return doc
 
     llm_caller = StructuredLLMCaller(
-        llm_service=llm_parser_args.llm_service,
+        llm_service=llm_caller_args.llm_service,
         usage_tracker=usage_tracker,
-        **llm_parser_args.llm_call_kwargs,
+        **llm_caller_args.llm_call_kwargs,
     )
-    chunks = llm_parser_args.text_splitter.split_text(doc.text)
+    chunks = llm_caller_args.text_splitter.split_text(doc.text)
     chunk_parser = ParseChunksWithMemory(llm_caller, chunks, num_to_recall=2)
     legal_text_validator = LegalTextValidator()
     ordinance_text_collector = ordinance_text_collector_class()

--- a/compass/extraction/apply.py
+++ b/compass/extraction/apply.py
@@ -18,12 +18,11 @@ logger = logging.getLogger(__name__)
 
 async def check_for_ordinance_info(
     doc,
-    text_splitter,
+    llm_parser_args,
     heuristic,
     ordinance_text_collector_class,
     permitted_use_text_collector_class,
     usage_tracker=None,
-    llm_call_kwargs=None,
 ):
     """Parse a single document for ordinance information
 
@@ -43,7 +42,7 @@ async def check_for_ordinance_info(
     usage_tracker : compass.services.usage.UsageTracker, optional
         Optional tracker instance to monitor token usage during
         LLM calls. By default, ``None``.
-    llm_call_kwargs : dict, optional
+    llm_parser_args : dict, optional
         Keyword arguments to be passed to the llm service ``call``
         method (i.e. `llm_service.call(**kwargs)`).
         Should *not* contain the following keys:
@@ -73,9 +72,11 @@ async def check_for_ordinance_info(
         return doc
 
     llm_caller = StructuredLLMCaller(
-        usage_tracker=usage_tracker, **(llm_call_kwargs or {})
+        llm_service=llm_parser_args.llm_service,
+        usage_tracker=usage_tracker,
+        **llm_parser_args.llm_call_kwargs,
     )
-    chunks = text_splitter.split_text(doc.text)
+    chunks = llm_parser_args.text_splitter.split_text(doc.text)
     chunk_parser = ParseChunksWithMemory(llm_caller, chunks, num_to_recall=2)
     legal_text_validator = LegalTextValidator()
     ordinance_text_collector = ordinance_text_collector_class()

--- a/compass/llm/__init__.py
+++ b/compass/llm/__init__.py
@@ -1,3 +1,8 @@
 """COMPASS Ordinance LLM callers"""
 
-from .calling import LLMCaller, ChatLLMCaller, StructuredLLMCaller
+from .calling import (
+    LLMCaller,
+    ChatLLMCaller,
+    StructuredLLMCaller,
+    LLMCallerArgs,
+)

--- a/compass/llm/calling.py
+++ b/compass/llm/calling.py
@@ -1,8 +1,15 @@
 """Ordinances LLM Calling classes"""
 
 import logging
+from functools import partial, cached_property
 
-from compass.utilities import llm_response_as_json
+import openai
+from elm import ApiBase
+from elm.utilities import validate_azure_api_params
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+from compass.services.openai import OpenAIService
+from compass.utilities import llm_response_as_json, RTS_SEPARATORS
 
 
 logger = logging.getLogger(__name__)
@@ -187,6 +194,93 @@ class StructuredLLMCaller(BaseLLMCaller):
             **self.kwargs,
         )
         return llm_response_as_json(response) if response else {}
+
+
+class LLMCallerArgs:
+    """Arguments to set up an LLM Caller instance initializer"""
+
+    def __init__(
+        self,
+        model="gpt-4o",
+        llm_call_kwargs=None,
+        llm_service_rate_limit=4000,
+        text_splitter_chunk_size=10_000,
+        text_splitter_chunk_overlap=1000,
+        client_kwargs=None,
+    ):
+        """
+
+        Parameters
+        ----------
+        model : str, optional
+            Name of LLM model to perform scraping.
+            By default, ``"gpt-4o"``.
+        llm_call_kwargs : dict, optional
+            Keyword arguments to be passed to the llm service ``call``
+            method (i.e. `llm_service.call(**kwargs)`).
+            Should *not* contain the following keys:
+
+                - usage_tracker
+                - usage_sub_label
+                - messages
+
+            These arguments are provided by the LLM Caller object.
+            By default, ``None``.
+        llm_service_rate_limit : int, optional
+            Token rate limit (i.e. tokens per minute) of LLM service
+            being used. By default, ``10_000``.
+        text_splitter_chunk_size : int, optional
+            Chunk size used to split the ordinance text. Parsing is
+            performed on each individual chunk. Units are in token count
+            of the model in charge of parsing ordinance text. Keeping
+            this value low can help reduce token usage since (free)
+            heuristics checks may be able to throw away irrelevant
+            chunks of text before passing to the LLM.
+            By default, ``10000``.
+        text_splitter_chunk_overlap : int, optional
+            Overlap of consecutive chunks of the ordinance text. Parsing
+            is performed on each individual chunk. Units are in token
+            count of the model in charge of parsing ordinance text.
+            By default, ``1000``.
+        client_kwargs : dict, optional
+            Keyword-value pairs to pass to underlying LLM client. These
+            typically include things like API keys and endpoints.
+            By default, ``None``.
+        """
+        self.model = model
+        self.llm_call_kwargs = llm_call_kwargs or {}
+        self.llm_service_rate_limit = llm_service_rate_limit
+        self.text_splitter_chunk_size = text_splitter_chunk_size
+        self.text_splitter_chunk_overlap = text_splitter_chunk_overlap
+        self.client_kwargs = client_kwargs or {}
+
+    @cached_property
+    def text_splitter(self):
+        """TextSplitter: Object that can be used to chunk text"""
+        return RecursiveCharacterTextSplitter(
+            RTS_SEPARATORS,
+            chunk_size=self.text_splitter_chunk_size,
+            chunk_overlap=self.text_splitter_chunk_overlap,
+            length_function=partial(ApiBase.count_tokens, model=self.model),
+            is_separator_regex=True,
+        )
+
+    @cached_property
+    def llm_service(self):
+        """LLMService: Object that can be used to submit calls to LLM"""
+        api_key, api_version, azure_endpoint = validate_azure_api_params(
+            self.client_kwargs.get("api_key"),
+            self.client_kwargs.get("api_version"),
+            self.client_kwargs.get("azure_endpoint"),
+        )
+        client = openai.AsyncAzureOpenAI(
+            api_key=api_key,
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
+        )
+        return OpenAIService(
+            client, self.model, rate_limit=self.llm_service_rate_limit
+        )
 
 
 def _add_json_instructions_if_needed(system_message):

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -99,11 +99,11 @@ async def download_county_ordinance(
     docs = await _down_select_docs_correct_content(
         docs,
         location=location,
-        text_splitter=llm_parser_args.text_splitter,
+        llm_parser_args=llm_parser_args,
         heuristic=heuristic,
         ordinance_text_collector_class=ordinance_text_collector_class,
         permitted_use_text_collector_class=permitted_use_text_collector_class,
-        llm_call_kwargs=llm_parser_args.llm_call_kwargs,
+        usage_tracker=usage_tracker,
     )
     logger.info(
         "Found %d potential ordinance documents for %s\n\t- %s",
@@ -164,15 +164,24 @@ async def _down_select_docs_correct_location(
 
 
 async def _down_select_docs_correct_content(
-    docs, location, usage_tracker, llm_parser_args
+    docs,
+    location,
+    llm_parser_args,
+    heuristic,
+    ordinance_text_collector_class,
+    permitted_use_text_collector_class,
+    usage_tracker,
 ):
     """Remove all documents that don't contain ordinance info"""
     return await filter_documents(
         docs,
         validation_coroutine=_contains_ordinances,
         task_name=location.full_name,
-        usage_tracker=usage_tracker,
         llm_parser_args=llm_parser_args,
+        heuristic=heuristic,
+        ordinance_text_collector_class=ordinance_text_collector_class,
+        permitted_use_text_collector_class=permitted_use_text_collector_class,
+        usage_tracker=usage_tracker,
     )
 
 

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -163,13 +163,13 @@ async def _down_select_docs_correct_content(docs, location, **kwargs):
     """Remove all documents that don't contain ordinance info"""
     return await filter_documents(
         docs,
-        validation_coroutine=_contains_ords,
+        validation_coroutine=_contains_ordinances,
         task_name=location.full_name,
         **kwargs,
     )
 
 
-async def _contains_ords(doc, **kwargs):
+async def _contains_ordinances(doc, **kwargs):
     """Helper coroutine that checks for ordinance info"""
     doc = await check_for_ordinance_info(doc, **kwargs)
     return doc.attrs.get("contains_ord_info", False)

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -83,7 +83,7 @@ async def download_county_ordinance(
         docs,
         location=location,
         usage_tracker=usage_tracker,
-        llm_call_kwargs=llm_parser_args.llm_call_kwargs,
+        llm_parser_args=llm_parser_args,
     )
     logger.info(
         "%d document(s) remaining after location filter for %s\n\t- %s",
@@ -145,11 +145,13 @@ async def _docs_from_web_search(
 
 
 async def _down_select_docs_correct_location(
-    docs, location, usage_tracker, llm_call_kwargs
+    docs, location, usage_tracker, llm_parser_args
 ):
     """Remove all documents not pertaining to the location"""
     llm_caller = StructuredLLMCaller(
-        usage_tracker=usage_tracker, **(llm_call_kwargs or {})
+        llm_service=llm_parser_args.llm_service,
+        usage_tracker=usage_tracker,
+        **llm_parser_args.llm_call_kwargs,
     )
     county_validator = CountyValidator(llm_caller)
     return await filter_documents(
@@ -162,7 +164,7 @@ async def _down_select_docs_correct_location(
 
 
 async def _down_select_docs_correct_content(
-    docs, location, usage_tracker, llm_call_kwargs
+    docs, location, usage_tracker, llm_parser_args
 ):
     """Remove all documents that don't contain ordinance info"""
     return await filter_documents(
@@ -170,7 +172,7 @@ async def _down_select_docs_correct_content(
         validation_coroutine=_contains_ordinances,
         task_name=location.full_name,
         usage_tracker=usage_tracker,
-        llm_call_kwargs=llm_call_kwargs,
+        llm_parser_args=llm_parser_args,
     )
 
 

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 async def download_county_ordinance(
     question_templates,
     location,
-    llm_parser_args,
+    llm_caller_args,
     heuristic,
     ordinance_text_collector_class,
     permitted_use_text_collector_class,
@@ -38,7 +38,7 @@ async def download_county_ordinance(
     ----------
     location : :class:`compass.utilities.location.Location`
         Location objects representing the county.
-    llm_parser_args : obj, optional
+    llm_caller_args : obj, optional
         TBA
     num_urls : int, optional
         Number of unique Google search result URL's to check for
@@ -70,7 +70,7 @@ async def download_county_ordinance(
     docs = await _docs_from_web_search(
         question_templates,
         location,
-        llm_parser_args.text_splitter,
+        llm_caller_args.text_splitter,
         num_urls,
         browser_semaphore,
         **(file_loader_kwargs or {}),
@@ -83,7 +83,7 @@ async def download_county_ordinance(
         docs,
         location=location,
         usage_tracker=usage_tracker,
-        llm_parser_args=llm_parser_args,
+        llm_caller_args=llm_caller_args,
     )
     logger.info(
         "%d document(s) remaining after location filter for %s\n\t- %s",
@@ -99,7 +99,7 @@ async def download_county_ordinance(
     docs = await _down_select_docs_correct_content(
         docs,
         location=location,
-        llm_parser_args=llm_parser_args,
+        llm_caller_args=llm_caller_args,
         heuristic=heuristic,
         ordinance_text_collector_class=ordinance_text_collector_class,
         permitted_use_text_collector_class=permitted_use_text_collector_class,
@@ -145,13 +145,13 @@ async def _docs_from_web_search(
 
 
 async def _down_select_docs_correct_location(
-    docs, location, usage_tracker, llm_parser_args
+    docs, location, usage_tracker, llm_caller_args
 ):
     """Remove all documents not pertaining to the location"""
     llm_caller = StructuredLLMCaller(
-        llm_service=llm_parser_args.llm_service,
+        llm_service=llm_caller_args.llm_service,
         usage_tracker=usage_tracker,
-        **llm_parser_args.llm_call_kwargs,
+        **llm_caller_args.llm_call_kwargs,
     )
     county_validator = CountyValidator(llm_caller)
     return await filter_documents(
@@ -166,7 +166,7 @@ async def _down_select_docs_correct_location(
 async def _down_select_docs_correct_content(
     docs,
     location,
-    llm_parser_args,
+    llm_caller_args,
     heuristic,
     ordinance_text_collector_class,
     permitted_use_text_collector_class,
@@ -177,7 +177,7 @@ async def _down_select_docs_correct_content(
         docs,
         validation_coroutine=_contains_ordinances,
         task_name=location.full_name,
-        llm_parser_args=llm_parser_args,
+        llm_caller_args=llm_caller_args,
         heuristic=heuristic,
         ordinance_text_collector_class=ordinance_text_collector_class,
         permitted_use_text_collector_class=permitted_use_text_collector_class,

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -23,14 +23,14 @@ logger = logging.getLogger(__name__)
 async def download_county_ordinance(
     question_templates,
     location,
-    text_splitter,
+    llm_parser_args,
     heuristic,
     ordinance_text_collector_class,
     permitted_use_text_collector_class,
     num_urls=5,
     file_loader_kwargs=None,
     browser_semaphore=None,
-    **kwargs,
+    usage_tracker=None,
 ):
     """Download the ordinance document(s) for a single county
 
@@ -38,13 +38,8 @@ async def download_county_ordinance(
     ----------
     location : :class:`compass.utilities.location.Location`
         Location objects representing the county.
-    text_splitter : obj, optional
-        Instance of an object that implements a `split_text` method.
-        The method should take text as input (str) and return a list
-        of text chunks. Raw text from HTML pages will be passed through
-        this splitter to split the single wep page into multiple pages
-        for the output document. Langchain's text splitters should work
-        for this input.
+    llm_parser_args : obj, optional
+        TBA
     num_urls : int, optional
         Number of unique Google search result URL's to check for
         ordinance document. By default, ``5``.
@@ -58,9 +53,9 @@ async def download_county_ordinance(
         Semaphore instance that can be used to limit the number of
         playwright browsers open concurrently. If ``None``, no limits
         are applied. By default, ``None``.
-    **kwargs
-        Keyword-value pairs used to initialize an
-        `compass.llm.LLMCaller` instance.
+    usage_tracker : compass.services.usage.UsageTracker, optional
+            Optional tracker instance to monitor token usage during
+            LLM calls. By default, ``None``.
 
     Returns
     -------
@@ -75,7 +70,7 @@ async def download_county_ordinance(
     docs = await _docs_from_web_search(
         question_templates,
         location,
-        text_splitter,
+        llm_parser_args.text_splitter,
         num_urls,
         browser_semaphore,
         **(file_loader_kwargs or {}),

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -85,7 +85,10 @@ async def download_county_ordinance(
         description="Checking files for correct jurisdiction...",
     )
     docs = await _down_select_docs_correct_location(
-        docs, location=location, **kwargs
+        docs,
+        location=location,
+        usage_tracker=usage_tracker,
+        llm_call_kwargs=llm_parser_args.llm_call_kwargs,
     )
     logger.info(
         "%d document(s) remaining after location filter for %s\n\t- %s",
@@ -146,9 +149,13 @@ async def _docs_from_web_search(
     )
 
 
-async def _down_select_docs_correct_location(docs, location, **kwargs):
+async def _down_select_docs_correct_location(
+    docs, location, usage_tracker, llm_call_kwargs
+):
     """Remove all documents not pertaining to the location"""
-    llm_caller = StructuredLLMCaller(**kwargs)
+    llm_caller = StructuredLLMCaller(
+        usage_tracker=usage_tracker, **(llm_call_kwargs or {})
+    )
     county_validator = CountyValidator(llm_caller)
     return await filter_documents(
         docs,

--- a/compass/scripts/download.py
+++ b/compass/scripts/download.py
@@ -101,11 +101,11 @@ async def download_county_ordinance(
     docs = await _down_select_docs_correct_content(
         docs,
         location=location,
-        text_splitter=text_splitter,
+        text_splitter=llm_parser_args.text_splitter,
         heuristic=heuristic,
         ordinance_text_collector_class=ordinance_text_collector_class,
         permitted_use_text_collector_class=permitted_use_text_collector_class,
-        **kwargs,
+        llm_call_kwargs=llm_parser_args.llm_call_kwargs,
     )
     logger.info(
         "Found %d potential ordinance documents for %s\n\t- %s",
@@ -159,13 +159,16 @@ async def _down_select_docs_correct_location(docs, location, **kwargs):
     )
 
 
-async def _down_select_docs_correct_content(docs, location, **kwargs):
+async def _down_select_docs_correct_content(
+    docs, location, usage_tracker, llm_call_kwargs
+):
     """Remove all documents that don't contain ordinance info"""
     return await filter_documents(
         docs,
         validation_coroutine=_contains_ordinances,
         task_name=location.full_name,
-        **kwargs,
+        usage_tracker=usage_tracker,
+        llm_call_kwargs=llm_call_kwargs,
     )
 
 

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -698,7 +698,6 @@ class _SingleJurisdictionRunner:
                 asyncio.create_task(
                     self._try_extract_ordinances(
                         possible_ord_doc,
-                        self.text_splitter,
                         extractor_class=extractor,
                         original_text_key=o_key,
                         cleaned_text_key=c_key,
@@ -718,7 +717,6 @@ class _SingleJurisdictionRunner:
     async def _try_extract_ordinances(
         self,
         possible_ord_doc,
-        text_splitter,
         extractor_class,
         original_text_key,
         cleaned_text_key,
@@ -735,7 +733,7 @@ class _SingleJurisdictionRunner:
         task_id = self._jsp.add_task(_TEXT_EXTRACTION_TASKS[extractor_class])
         doc = await _extract_ordinance_text(
             possible_ord_doc,
-            text_splitter,
+            self.text_splitter,
             extractor_class=extractor_class,
             original_text_key=original_text_key,
             usage_tracker=self.usage_tracker,

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -205,7 +205,7 @@ async def process_counties_with_openai(  # noqa: PLR0917, PLR0913
         By default, ``None``, which runs the extraction for all known
         jurisdictions (this is untested and not currently recommended).
     model : str, optional
-        Name of LLM model to perform scraping. By default, ``"gpt-4"``.
+        Name of LLM model to perform scraping. By default, ``"gpt-4o"``.
     azure_api_key : str, optional
         Azure OpenAI API key. By default, ``None``, which pulls the key
         from the environment variable ``AZURE_OPENAI_API_KEY`` instead.
@@ -277,18 +277,18 @@ async def process_counties_with_openai(  # noqa: PLR0917, PLR0913
     clean_dir : path-like, optional
         Path to directory for cleaned ordinance text output. This
         directory will be created if it does not exist. By default,
-        ``None``, which creates a ``clean`` folder in the output
+        ``None``, which creates a ``cleaned_text`` folder in the output
         directory for the cleaned ordinance text files.
     ordinance_file_dir : path-like, optional
         Path to directory for individual county ordinance file outputs.
         This directory will be created if it does not exist.
-        By default, ``None``, which creates a ``county_ord_files``
+        By default, ``None``, which creates a ``ordinance_files``
         folder in the output directory.
     county_dbs_dir : path-like, optional
         Path to directory for individual county ordinance database
         outputs. This directory will be created if it does not exist.
-        By default, ``None``, which creates a ``county_dbs`` folder in
-        the output directory.
+        By default, ``None``, which creates a ``jurisdiction_dbs``
+        folder in the output directory.
     log_level : str, optional
         Log level to set for county retrieval and parsing loggers.
         By default, ``"INFO"``.

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -931,29 +931,6 @@ def _concat_scrape_results(doc):
     return doc
 
 
-def _docs_to_db(docs):
-    """Convert list of docs to output database"""
-    db = []
-    for doc in docs:
-        if doc is None or isinstance(doc, Exception):
-            continue
-
-        if num_ordinances_in_doc(doc) == 0:
-            continue
-
-        results = _db_results(doc)
-        results = _formatted_db(results)
-        db.append(results)
-
-    if not db:
-        return pd.DataFrame(columns=PARSED_COLS), 0
-
-    num_jurisdictions_found = len(db)
-    db = pd.concat(db)
-    db = _empirical_adjustments(db)
-    return _formatted_db(db), num_jurisdictions_found
-
-
 def _doc_infos_to_db(doc_infos):
     """Convert list of docs to output database"""
     db = []

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -556,7 +556,7 @@ class _SingleJurisdictionRunner:
     ):
         self.tech_specs = _compile_tech_specs(tech)
         self.jurisdiction = jurisdiction
-        self.llm_parser_args = llm_caller_args
+        self.llm_caller_args = llm_caller_args
         self.web_search_params = web_search_params
         self.file_loader_kwargs = file_loader_kwargs
         self.browser_semaphore = browser_semaphore
@@ -692,7 +692,7 @@ class _SingleJurisdictionRunner:
             extractor_class=extractor_class,
             original_text_key=original_text_key,
             usage_tracker=self.usage_tracker,
-            llm_parser_args=self.llm_caller_args,
+            llm_caller_args=self.llm_caller_args,
         )
         await self._record_usage()
         self._jsp.remove_task(task_id)
@@ -702,7 +702,7 @@ class _SingleJurisdictionRunner:
             text_key=cleaned_text_key,
             out_key=out_key,
             usage_tracker=self.usage_tracker,
-            llm_parser_args=self.llm_caller_args,
+            llm_caller_args=self.llm_caller_args,
         )
         await self._record_usage()
         return out

--- a/compass/services/provider.py
+++ b/compass/services/provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import contextlib
 
 from compass.services.queues import (
     initialize_service_queue,
@@ -130,6 +131,12 @@ class RunningAsyncServices:
     async def __aenter__(self):
         for service in self.services:
             logger.debug("Initializing Service: %s", service.name)
+            with contextlib.suppress(AttributeError):
+                logger.debug(
+                    "    ↪ model_name=%r, rate_limit=%d",
+                    service.model_name,
+                    service.rate_limit,
+                )
             queue = initialize_service_queue(service.name)
             service.acquire_resources()
             task = asyncio.create_task(_RunningProvider(service, queue).run())

--- a/compass/services/threaded.py
+++ b/compass/services/threaded.py
@@ -333,10 +333,11 @@ class UsageUpdater(ThreadedService):
         """
         self._is_processing = True
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
+        out = await loop.run_in_executor(
             self.pool, _dump_usage, self.usage_fp, tracker
         )
         self._is_processing = False
+        return out
 
 
 class JurisdictionUpdater(ThreadedService):
@@ -405,9 +406,13 @@ def _dump_usage(fp, tracker):
         with Path.open(fp, encoding="utf-8") as fh:
             usage_info = json.load(fh)
 
-    tracker.add_to(usage_info)
-    with Path.open(fp, "w", encoding="utf-8") as fh:
-        json.dump(usage_info, fh, indent=4)
+    if tracker is not None:
+        tracker.add_to(usage_info)
+
+        with Path.open(fp, "w", encoding="utf-8") as fh:
+            json.dump(usage_info, fh, indent=4)
+
+    return usage_info
 
 
 def _dump_jurisdiction_info(fp, county, doc, seconds_elapsed):


### PR DESCRIPTION
This PR consolidates the kwargs into a single class in preparation for passing around multiple model specifications