### PR TITLE
Filter output CSV

### DIFF
--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -61,6 +61,7 @@ from compass.utilities import (
     extract_ord_year_from_doc_attrs,
     num_ordinances_in_doc,
     num_ordinances_dataframe,
+    ordinances_bool_index,
 )
 from compass.utilities.enums import LLMTasks
 from compass.utilities.location import County
@@ -1065,7 +1066,8 @@ def _formatted_db(db):
             db[col] = None
 
     db["quantitative"] = db["quantitative"].astype("boolean").fillna(True)
-    return db[PARSED_COLS]
+    ord_rows = ordinances_bool_index(db)
+    return db[ord_rows][PARSED_COLS].reset_index(drop=True)
 
 
 def _save_db(db, out_dir):

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -252,12 +252,12 @@ async def process_counties_with_openai(  # noqa: PLR0917, PLR0913
             url_ignore_substrings = [
                 "wikipedia",
                 "nrel.gov",
-                "www.co.delaware.in.us/egov/documents/1649699794_0382.pdf",
+                "www.co.delaware.in.us/documents/1649699794_0382.pdf",
             ]
 
         The above configuration would ignore all `wikipedia` articles,
         all websites on the NREL domain, and the specific file located
-        at `www.co.delaware.in.us/egov/documents/1649699794_0382.pdf`.
+        at `www.co.delaware.in.us/documents/1649699794_0382.pdf`.
         By default, ``None``.
     file_loader_kwargs : dict, optional
         Dictionary of keyword arguments pairs to initialize

--- a/compass/utilities/__init__.py
+++ b/compass/utilities/__init__.py
@@ -7,6 +7,7 @@ from .parsing import (
     merge_overlapping_texts,
     num_ordinances_in_doc,
     num_ordinances_dataframe,
+    ordinances_bool_index,
 )
 
 

--- a/compass/utilities/parsing.py
+++ b/compass/utilities/parsing.py
@@ -156,6 +156,24 @@ def num_ordinances_dataframe(data):
     int
         Number of unique ordinance values extracted from this DataFrame.
     """
+    return ordinances_bool_index(data).sum()
+
+
+def ordinances_bool_index(data):
+    """Array of bools indicating rows containing ordinances in DataFrame
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        DataFrame potentially containing ordinances for a jurisdiction.
+        If no ordinance values are found, this function returns ``0``.
+
+    Returns
+    -------
+    array-like
+        Array of bools indicating rows containing ordinances in
+        DataFrame.
+    """
     if data is None:
         return 0
 
@@ -167,4 +185,4 @@ def num_ordinances_dataframe(data):
         return 0
 
     found_features = (~data[check_cols].isna()).to_numpy().sum(axis=1)
-    return (found_features > 0).sum()
+    return found_features > 0

--- a/examples/parse_existing_docs/README.rst
+++ b/examples/parse_existing_docs/README.rst
@@ -66,7 +66,7 @@ Next, we'll configure how we want to interact with an OpenAI large language mode
 
     from compass.llm import OpenAIConfig
 
-    caller_args = OpenAIConfig(
+    llm_config = OpenAIConfig(
         name="gpt-4o-mini",
         llm_call_kwargs={"temperature": 0},
         llm_service_rate_limit=500_000,
@@ -132,7 +132,7 @@ in the document. Here's how that might look:
 
     doc = await check_for_ordinance_info(
         doc,
-        llm_callers=caller_args,
+        model_config=llm_config,
         heuristic=SolarHeuristic(),
         ordinance_text_collector_class=SolarOrdinanceTextCollector,
         permitted_use_text_collector_class=None,
@@ -141,7 +141,7 @@ in the document. Here's how that might look:
 
 What this function does is scan the text for solar-related ordinance language. If it finds any, it stores the relevant
 (concatenated) chunks in ``doc.attrs["ordinance_text"]``. To call this function, we passed in the document along with
-the LLM calling arguments that we set up in `Setting Up the LLM Caller`_. We also specified the use of the
+the LLM calling arguments that we set up in `Setting Up the LLM Configuration`_. We also specified the use of the
 :class:`~compass.extraction.solar.ordinance.SolarHeuristic`, which helps reduce LLM costs by applying a simple
 keyword-based heuristic to each document chunk before sending it to the LLM. Finally, we indicated that the
 :class:`~compass.extraction.solar.ordinance.SolarOrdinanceTextCollector` class should be used to search for solar ordinance
@@ -170,9 +170,9 @@ We'll do that using the :func:`~compass.extraction.apply.extract_ordinance_text_
 
     doc, ord_text_key = await extract_ordinance_text_with_llm(
         doc,
-        caller_args.text_splitter,
+        llm_config.text_splitter,
         extractor=SolarOrdinanceTextExtractor(
-            LLMCaller(llm_service=caller_args.llm_service)
+            LLMCaller(llm_service=llm_config.llm_service)
         ),
         original_text_key="ordinance_text",
     )
@@ -208,7 +208,7 @@ structured data:
     doc = await extract_ordinance_values(
         doc,
         parser=StructuredSolarOrdinanceParser(
-            llm_service=caller_args.llm_service
+            llm_service=llm_config.llm_service
         ),
         text_key=ord_text_key,
         out_key="ordinance_values",


### PR DESCRIPTION
Perform some filtering before writing output so that users get a more focused report of the ordinances at a glance and so that the DB can save all rows from the file.