### PR TITLE
Use tag for OpenAI services

### DIFF
--- a/compass/llm/config.py
+++ b/compass/llm/config.py
@@ -100,6 +100,7 @@ class OpenAIConfig(LLMConfig):
         text_splitter_chunk_overlap=1000,
         client_type="azure",
         client_kwargs=None,
+        tag=None,
     ):
         """
 
@@ -142,6 +143,13 @@ class OpenAIConfig(LLMConfig):
             Keyword-value pairs to pass to underlying LLM client. These
             typically include things like API keys and endpoints.
             By default, ``None``.
+        tag : str, optional
+            Optional tag to distinguish this model config from another
+            model config for the same model `name`. This is useful if
+            you have the same model (e.g. `gpt-4o-mini`) running on two
+            different endpoints. If you have duplicate model names and
+            don't specify this tag, one will be created for you. By
+            default, ``None``.
         """
         super().__init__(
             name=name,
@@ -152,6 +160,7 @@ class OpenAIConfig(LLMConfig):
         )
         self.client_type = client_type.casefold()
         self._client_kwargs = client_kwargs or {}
+        self._tag = tag or ""
 
         self._validate_client_type()
 

--- a/compass/llm/config.py
+++ b/compass/llm/config.py
@@ -182,7 +182,10 @@ class OpenAIConfig(LLMConfig):
         self._OPENAI_MODEL_NAMES.update([self.name])
         num_models = self._OPENAI_MODEL_NAMES.get(self.name, 1)
         if num_models > 1 and not self._tag:
-            self._tag = f"-{num_models - 1}"
+            self._tag = f"{num_models - 1}"
+
+        if self._tag and not self._tag.startswith("-"):
+            self._tag = f"-{self._tag}"
 
     @cached_property
     def client_kwargs(self):

--- a/compass/llm/config.py
+++ b/compass/llm/config.py
@@ -204,5 +204,8 @@ class OpenAIConfig(LLMConfig):
         """LLMService: Object that can be used to submit calls to LLM"""
         client = self.SUPPORTED_CLIENTS[self.client_type](**self.client_kwargs)
         return OpenAIService(
-            client, self.name, rate_limit=self.llm_service_rate_limit
+            client,
+            self.name,
+            rate_limit=self.llm_service_rate_limit,
+            service_tag=self._tag,
         )

--- a/compass/llm/config.py
+++ b/compass/llm/config.py
@@ -1,6 +1,7 @@
 """Ordinances LLM Configurations"""
 
 import os
+from collections import Counter
 from abc import ABC, abstractmethod
 from functools import partial, cached_property
 
@@ -91,6 +92,8 @@ class OpenAIConfig(LLMConfig):
     }
     """Currently-supported OpenAI LLM clients"""
 
+    _OPENAI_MODEL_NAMES = Counter()
+
     def __init__(
         self,
         name="gpt-4o",
@@ -163,6 +166,7 @@ class OpenAIConfig(LLMConfig):
         self._tag = tag or ""
 
         self._validate_client_type()
+        self._validate_tag()
 
     def _validate_client_type(self):
         """Validate that user input a known client type"""
@@ -172,6 +176,13 @@ class OpenAIConfig(LLMConfig):
                 f"clients: {list(self.SUPPORTED_CLIENTS)}"
             )
             raise COMPASSValueError(msg)
+
+    def _validate_tag(self):
+        """Update tag if needed"""
+        self._OPENAI_MODEL_NAMES.update([self.name])
+        num_models = self._OPENAI_MODEL_NAMES.get(self.name, 1)
+        if num_models > 1 and not self._tag:
+            self._tag = f"-{num_models - 1}"
 
     @cached_property
     def client_kwargs(self):

--- a/compass/services/base.py
+++ b/compass/services/base.py
@@ -140,7 +140,7 @@ class LLMService(Service):
             A TimeBoundedUsageTracker instance. This will be used to
             track usage per time interval and compare to `rate_limit`.
         service_tag : str, optional
-            optional tag to use to distinguish service (i.e. make unique
+            Optional tag to use to distinguish service (i.e. make unique
             from other services). Must set this if multiple models with
             the same name are run concurrently. By default, ``None``.
         """

--- a/compass/services/openai.py
+++ b/compass/services/openai.py
@@ -123,7 +123,7 @@ class OpenAIService(LLMService):
             If ``None``, a `TimeBoundedUsageTracker` instance is created
             with default parameters. By default, ``None``.
         service_tag : str, optional
-            optional tag to use to distinguish service (i.e. make unique
+            Optional tag to use to distinguish service (i.e. make unique
             from other services). Must set this if multiple models with
             the same name are run concurrently. By default, ``None``.
         """


### PR DESCRIPTION
This allows users to set up services for same model name but different endpoint, or same model name and end point but different rate/text splitter parameters and different tasks. Essentially maximal flexibility in specifying OpenAI models.