### PR TITLE
Fix task for pixi v0.46

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -15678,8 +15678,8 @@ packages:
   timestamp: 1733408419340
 - pypi: .
   name: nrel-compass
-  version: 0.2.1.dev19+g849f8ab.d20250414
-  sha256: 3a766617b04b72568eaa2111776682a6ab122eb4a59fa244393cd69d78e7ccd0
+  version: 0.4.1.dev5+g1f19408.d20250424
+  sha256: 1f115ffac51ccf61141603fc3967a4e1adbf7ffb27d8bae5af405343410571a9
   requires_dist:
   - click>=8.1.7,<9
   - langchain>=0.3.7,<0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ pdoc = { features = ["python-default", "python-doc", "doc"], solve-group = "pyth
 pbuild = { features = ["python-build"], solve-group = "python" }
 
 [tool.pixi.tasks]
-openai-solar-demo = { cmd = "compass process -c config.json5", args = ["api_key"], env = { OPENAI_API_KEY = "{{ api_key }}"}, cwd = "examples/openai_solar_demo"}
+openai-solar-demo = { cmd = "export OPENAI_API_KEY={{ api_key }}; compass process -c config.json5", args = ["api_key"], cwd = "examples/openai_solar_demo"}
 
 [tool.pixi.feature.python-test.tasks]
 tests = "pytest --durations=20 tests/python"


### PR DESCRIPTION
Demo run tasks was breaking because of templating changes in pixi v0.46. Fix the task command so that templating should no longer break