### PR TITLE
GitHub cache Fine Tuning

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "gha"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run cargo check
@@ -55,6 +56,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "gha"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run cargo fmt
@@ -99,6 +101,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "gha"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: pixi run -e rdev --frozen cargo test --workspace --no-fail-fast
@@ -122,6 +125,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "gha"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Publish crates (core library)

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -22,9 +22,11 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          pixi-version: v0.47.0
-          cache: true
+          pixi-version: v0.48.0
           frozen: true
+          cache: true
+          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          environments: pdev rdev
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -32,7 +34,7 @@ jobs:
 
       - name: Run cargo check
         run: |
-          pixi run --frozen cargo check --workspace
+          pixi run -e rdev --frozen cargo check --workspace
 
   lints:
     # Only run tests if code looks OK
@@ -45,9 +47,11 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          pixi-version: v0.47.0
-          cache: true
+          pixi-version: v0.48.0
           frozen: true
+          cache: true
+          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          environments: pdev rdev
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -55,11 +59,11 @@ jobs:
 
       - name: Run cargo fmt
         run: |
-          pixi run --frozen cargo fmt --all --check
+          pixi run -e rdev --frozen cargo fmt --all --check
 
       - name: Run cargo clippy
         run: |
-          pixi run --frozen cargo clippy --all-features --tests -- -D warnings
+          pixi run -e rdev --frozen cargo clippy --all-features --tests -- -D warnings
 
   test:
     # Only run tests if code looks OK
@@ -87,15 +91,17 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          pixi-version: v0.47.0
-          cache: true
+          pixi-version: v0.48.0
           frozen: true
+          cache: true
+          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          environments: pdev rdev
 
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - run: pixi run --frozen cargo test --workspace --no-fail-fast
+      - run: pixi run -e rdev --frozen cargo test --workspace --no-fail-fast
 
   publish:
     name: Publish (dry-run)
@@ -108,9 +114,11 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          pixi-version: v0.47.0
-          cache: true
+          pixi-version: v0.48.0
           frozen: true
+          cache: true
+          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          environments: pdev rdev
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,14 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          pixi-version: v0.47.0
+          pixi-version: v0.48.0
           locked: true
           cache: true
+          cache-write: ${{ github.ref == 'refs/heads/main' }}
+          environments: pdev rdev
 
       - name: Build Docs
-        run: pixi run -e pdoc make-html
+        run: pixi run -e pdev make-html
 
       - name: deploy
         uses: peaceiris/actions-gh-pages@v4.0.0

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -18,12 +18,14 @@ jobs:
 
     - uses: prefix-dev/setup-pixi@v0.8.8
       with:
-        pixi-version: v0.47.0
+        pixi-version: v0.48.0
         locked: true
         cache: true
+        cache-write: ${{ github.ref == 'refs/heads/main' }}
+        environments: pdev rdev
 
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: pixi run -e pbuild upload-wheels
+      run: pixi run -e pdev upload-wheels

--- a/docs/source/dev/README.rst
+++ b/docs/source/dev/README.rst
@@ -203,17 +203,37 @@ Miscellaneous
 A collection of other miscellaneous guidelines.
 
 
-Updating ``pyproject.toml``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GitHub Actions Cache and Updating ``pyproject.toml``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Because we statically link the requirements, the compilation process can
 extend to 30-60 minutes. That is mostly due to ``duckdb`` and ``tokio``. To
-optimize this process, we use a GiHub Actions cache, but too many images blow
-the quota make the process less useful. To avoid this, the Rust component is setup
-to only save the compiled cache for branch main, and all other branches initiate
-from that, and hopefully save some fair amount of time. Thus, a good practice here
-is to update the `pyproject.toml` file and/or any Rust dependencies in a dedicated
-branch to avoid too much recompilation in working branches.
+optimize this process, we use a GiHub Actions cache.
+
+When using the GitHub cache system, we have to be mindful of the 10 GB limit.
+If we place too many items in the cache, it will rotate too frequently and
+defeat the purpose of the cache. For this reason, **we only cache environments
+that are run in actions on the ``main`` branch**!
+
+With this system, any PR can then pull from the cache built on the main branch
+and set up their environments that way.
+
+What this means for you
+"""""""""""""""""""""""
+When you open a PR, your environment will be built from a cache from the main branch.
+If you have no dependency updates, you are good to go!
+
+However, if you do have dependency updates, your environment will need to be updated.
+If you are working with Rust, you will download and compile the extra crate(s) in your
+branch. If the crate is small, this may not be a big deal, but keep in mind that this
+will happen for every new commit you push to your open PR.
+
+If you updated something in the pixi environment, the whole environment will be re-built.
+
+Therefore, in both of th latter cases, a good practice is to put your dependency updates
+in a separate branch and dedicated PR that you merge to ``main``. Then, your feature PR
+can make full use of the cache that is built on the main branch without having to re-build
+or re-compile anything for the environment.
 
 
 Error Handling


### PR DESCRIPTION
Fine tune the GHA cache:

- Pixi env now only cached on main, which is in line with what we do for Rust. Since caches can only be accessed from the current branch or `main` ([source](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)), it doesn't make sense to store them for a branch. However, this means we should follow the same pattern as for Rust: **Do your pyproject toml updates in a separate PR and push to main, then add your logic changes in a separate PR** (or pay the price of building a pixi env every time). I updated some guidance on this in the dev documentation.
- If we don't explicitly list the environment in the `setup-pixi` action, [it will only build and cache the default environment](https://github.com/prefix-dev/setup-pixi?tab=readme-ov-file#install-multiple-environments-in-one-job). For this reason, I went ahead and added the `pdev` and `rdev` envs as requirement. This may make the cache file too big. Let's keep an eye on this. If it's too large, it may be worth it to create a combined python and rust `dev` environment and only cache that.
- Update rust cache key to use a shared `"gha"` tag so that we are not building a cache for every single job

Bonus update bumps pixi version to 0.48.0