### PR TITLE
Fix PyPi build action

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -19,10 +19,10 @@ jobs:
         pixi-version: v0.48.0
         locked: true
         cache: false
-        environments: pdev
+        environments: pbuild
 
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: pixi run -e pdev upload-wheels
+      run: pixi run -e pbuild upload-wheels


### PR DESCRIPTION
Revert to using `pbuild` env since we are not using the cache anymore for build action.