### PR TITLE
Capitalization updates

### DIFF
--- a/compass/utilities/__init__.py
+++ b/compass/utilities/__init__.py
@@ -1,5 +1,6 @@
 """Ordinance utilities"""
 
+from .base import title_preserving_caps
 from .jurisdictions import (
     load_all_jurisdiction_info,
     load_jurisdictions_from_fp,

--- a/compass/utilities/base.py
+++ b/compass/utilities/base.py
@@ -1,0 +1,22 @@
+"""Base COMPASS utility functions"""
+
+
+def title_preserving_caps(string):
+    """Convert string to title case, preserving existing capitalization
+
+    Parameters
+    ----------
+    string : str
+        Input string potentially containing capitalized words.
+
+    Returns
+    -------
+    str
+        String converted to title case, preserving existing
+        capitalization.
+    """
+    return " ".join(map(_cap, string.split(" ")))
+
+
+def _cap(word):
+    return "".join([word[0].upper(), word[1:]])

--- a/compass/utilities/jurisdictions.py
+++ b/compass/utilities/jurisdictions.py
@@ -26,10 +26,7 @@ def load_all_jurisdiction_info():
         DataFrame containing info like names, FIPS, websites, etc. for
         all jurisdictions.
     """
-    jurisdiction_info = pd.read_csv(_COUNTY_DATA_FP).replace({np.nan: None})
-    jurisdiction_info = _convert_to_title(jurisdiction_info, "State")
-    jurisdiction_info = _convert_to_title(jurisdiction_info, "County")
-    return _convert_to_title(jurisdiction_info, "Subdivision")
+    return pd.read_csv(_COUNTY_DATA_FP).replace({np.nan: None})
 
 
 def jurisdiction_websites(jurisdiction_info=None):
@@ -73,7 +70,7 @@ def load_jurisdictions_from_fp(jurisdiction_fp):
         websites, etc. for all requested jurisdictions (that were
         found).
     """
-    jurisdictions = pd.read_csv(jurisdiction_fp)
+    jurisdictions = pd.read_csv(jurisdiction_fp).replace({np.nan: None})
     jurisdictions = _validate_jurisdiction_input(jurisdictions)
 
     all_jurisdiction_info = load_all_jurisdiction_info()
@@ -99,12 +96,8 @@ def _validate_jurisdiction_input(jurisdictions):
         msg = "The jurisdiction input must have at least a 'State' column!"
         raise COMPASSValueError(msg)
 
-    jurisdictions = _convert_to_title(jurisdictions, "State")
-
     if "County" not in jurisdictions:
         jurisdictions["County"] = None
-    else:
-        jurisdictions = _convert_to_title(jurisdictions, "County")
 
     if "Subdivision" in jurisdictions:
         if "Jurisdiction Type" not in jurisdictions:
@@ -115,7 +108,6 @@ def _validate_jurisdiction_input(jurisdictions):
             )
             raise COMPASSValueError(msg)
 
-        jurisdictions = _convert_to_title(jurisdictions, "Subdivision")
         jurisdictions["Jurisdiction Type"] = jurisdictions[
             "Jurisdiction Type"
         ].str.casefold()
@@ -157,9 +149,3 @@ def _format_jurisdiction_df_for_output(df):
     ]
     df["FIPS"] = df["FIPS"].astype(int)
     return df[out_cols].replace({np.nan: None}).reset_index(drop=True)
-
-
-def _convert_to_title(df, column):
-    """Convert the values of a DataFrame column to titles"""
-    df[column] = df[column].str.strip().str.casefold().str.title()
-    return df

--- a/compass/utilities/location.py
+++ b/compass/utilities/location.py
@@ -39,22 +39,28 @@ class Jurisdiction:
             applicable. If the jurisdiction represents a state, leave
             this input unspecified. If the jurisdiction represents a
             county or a subdivision within a county, provide the county
-            name here. By default, ``None``.
+            name here.
+
+            .. IMPORTANT:: Make sure this input is capitalized properly!
+
+            By default, ``None``.
         subdivision_name : str, optional
             Name of the subdivision that the jurisdiction represents, if
             applicable. If the jurisdiction represents a state or
             county, leave this input unspecified. Otherwise, provide the
-            jurisdiction name here. By default, ``None``.
+            jurisdiction name here.
+
+            .. IMPORTANT:: Make sure this input is capitalized properly!
+
+            By default, ``None``.
         code : int or str, optional
             Optional jurisdiction code (typically FIPS or similar).
             By default, ``None``.
         """
         self.type = subdivision_type.title()
         self.state = state.title()
-        self.county = county.title() if county else None
-        self.subdivision_name = (
-            subdivision_name.title() if subdivision_name else None
-        )
+        self.county = county
+        self.subdivision_name = subdivision_name
         self.code = code
 
     @cached_property

--- a/tests/python/utilities/test_utilities_base.py
+++ b/tests/python/utilities/test_utilities_base.py
@@ -1,0 +1,23 @@
+"""Test COMPASS Ordinance logging logic."""
+
+from pathlib import Path
+
+import pytest
+
+from compass.utilities.base import title_preserving_caps
+
+
+def test_title_preserving_caps():
+    """Test the `title_preserving_caps` function"""
+
+    assert title_preserving_caps("hello world") == "Hello World"
+    assert title_preserving_caps("hello World") == "Hello World"
+    assert title_preserving_caps("Hello world") == "Hello World"
+    assert title_preserving_caps("Hello World") == "Hello World"
+    assert title_preserving_caps("HELLO WORLD") == "HELLO WORLD"
+
+    assert title_preserving_caps("St. mcLean") == "St. McLean"
+
+
+if __name__ == "__main__":
+    pytest.main(["-q", "--show-capture=all", Path(__file__), "-rapP"])

--- a/tests/python/utilities/test_utilities_jurisdictions.py
+++ b/tests/python/utilities/test_utilities_jurisdictions.py
@@ -12,6 +12,7 @@ from compass.utilities.jurisdictions import (
     jurisdiction_websites,
 )
 from compass.exceptions import COMPASSValueError
+from compass.warn import COMPASSWarning
 
 
 def test_load_jurisdictions():
@@ -65,7 +66,15 @@ def test_load_jurisdictions_from_fp(tmp_path):
     )
     input_jurisdictions.to_csv(test_jurisdiction_fp)
 
-    jurisdictions = load_jurisdictions_from_fp(test_jurisdiction_fp)
+    with pytest.warns(COMPASSWarning) as record:
+        jurisdictions = load_jurisdictions_from_fp(test_jurisdiction_fp)
+
+    assert len(record) == 1
+    warning_msg = str(record[0].message)
+
+    assert "nan" not in warning_msg
+    assert "DNE County" in warning_msg
+    assert "colorado" in warning_msg
 
     assert len(jurisdictions) == 1
     assert set(jurisdictions["County"]) == {"Decatur"}

--- a/tests/python/utilities/test_utilities_location.py
+++ b/tests/python/utilities/test_utilities_location.py
@@ -41,7 +41,7 @@ def test_basic_county_properties():
     assert county.full_county_phrase == "Box Elder County"
     assert not county.full_subdivision_phrase
 
-    assert county == Jurisdiction("county", county="Box elder", state="uTah")
+    assert county != Jurisdiction("county", county="Box elder", state="uTah")
     assert county != Jurisdiction("city", county="Box Elder", state="Utah")
 
     assert county == "Box Elder County, Utah"
@@ -61,6 +61,9 @@ def test_basic_parish_properties():
     assert not parish.full_subdivision_phrase
 
     assert parish == Jurisdiction(
+        "parish", county="Assumption", state="lOuisiana"
+    )
+    assert parish != Jurisdiction(
         "parish", county="assumption", state="lOuisiana"
     )
     assert parish != Jurisdiction(
@@ -88,7 +91,13 @@ def test_basic_town_properties(jt):
     assert town.full_subdivision_phrase == f"{jt.title()} of Golden"
 
     assert town == Jurisdiction(
-        jt, county="jefferson", state="colorado", subdivision_name="golden"
+        jt, county="Jefferson", state="colorado", subdivision_name="Golden"
+    )
+    assert town != Jurisdiction(
+        jt, county="jefferson", state="colorado", subdivision_name="Golden"
+    )
+    assert town != Jurisdiction(
+        jt, county="Jefferson", state="colorado", subdivision_name="golden"
     )
     assert town != Jurisdiction(
         "county",
@@ -115,7 +124,13 @@ def test_atypical_subdivision_properties():
     assert gore.full_subdivision_phrase == "Buels Gore"
 
     assert gore == Jurisdiction(
-        "gore", county="chittenden", state="vermont", subdivision_name="buels"
+        "gore", county="Chittenden", state="vermont", subdivision_name="Buels"
+    )
+    assert gore != Jurisdiction(
+        "gore", county="chittenden", state="vermont", subdivision_name="Buels"
+    )
+    assert gore != Jurisdiction(
+        "gore", county="Chittenden", state="vermont", subdivision_name="buels"
     )
     assert gore != Jurisdiction(
         "county",
@@ -141,6 +156,9 @@ def test_city_no_county():
     assert gore.full_subdivision_phrase == "City of Baltimore"
 
     assert gore == Jurisdiction(
+        "city", "maryland", subdivision_name="Baltimore"
+    )
+    assert gore != Jurisdiction(
         "city", "maryland", subdivision_name="baltimore"
     )
     assert gore != Jurisdiction(
@@ -169,24 +187,24 @@ def test_full_name_the_prefixed_property():
     )
 
     for st in JURISDICTION_TYPES_AS_PREFIXES:
-        jur = Jurisdiction(st, state="Colorado", subdivision_name="test")
+        jur = Jurisdiction(st, state="Colorado", subdivision_name="Test")
         assert (
             jur.full_name_the_prefixed == f"the {st.title()} of Test, Colorado"
         )
 
-    jur = Jurisdiction(st, state="Colorado", subdivision_name="test")
+    jur = Jurisdiction(st, state="Colorado", subdivision_name="Test")
     assert jur.full_name_the_prefixed == f"the {st.title()} of Test, Colorado"
 
     jur = Jurisdiction(
         "census county division",
         state="Colorado",
-        county="test a",
-        subdivision_name="test b",
+        county="Test a",
+        subdivision_name="Test b",
     )
 
     assert (
         jur.full_name_the_prefixed
-        == "Test B Census County Division, Test A County, Colorado"
+        == "Test b Census County Division, Test a County, Colorado"
     )
 
 
@@ -194,7 +212,7 @@ def test_full_subdivision_phrase_the_prefixed_property():
     """Test ``Jurisdiction.full_subdivision_phrase_the_prefixed`` property"""
 
     for st in JURISDICTION_TYPES_AS_PREFIXES:
-        jur = Jurisdiction(st, state="Colorado", subdivision_name="test")
+        jur = Jurisdiction(st, state="Colorado", subdivision_name="Test")
         assert (
             jur.full_subdivision_phrase_the_prefixed
             == f"the {st.title()} of Test"
@@ -203,13 +221,13 @@ def test_full_subdivision_phrase_the_prefixed_property():
     jur = Jurisdiction(
         "census county division",
         state="Colorado",
-        county="test a",
-        subdivision_name="test b",
+        county="Test a",
+        subdivision_name="Test b",
     )
 
     assert (
         jur.full_subdivision_phrase_the_prefixed
-        == "Test B Census County Division"
+        == "Test b Census County Division"
     )
 
 


### PR DESCRIPTION
We can't apply `.title()` to county and subdivision names, because that converts things like `McLean` to `Mclean`. Instead, let's assume that the user properly capitalized those inputs (and add a warning to the docs for users to do so).