### PR TITLE
Typo - table name

### DIFF
--- a/crates/compass/src/scraper/usage.rs
+++ b/crates/compass/src/scraper/usage.rs
@@ -167,7 +167,7 @@ impl Usage {
                 tracing::trace!("Writing usage for model {:?} to the database", model_name);
 
                 let model_id: u32 = conn.query_row(
-                    "INSERT INTO usage_per_model (jurisdiction_lnk, model, total_requests, total_prompt_tokens, total_response_tokens) VALUES (?, ?, ?, ?, ?) RETURNING id",
+                    "INSERT INTO usage_model (usage_lnk, model, total_requests, total_prompt_tokens, total_response_tokens) VALUES (?, ?, ?, ?, ?) RETURNING id",
                     [
                         &jurisdiction_id.to_string(),
                         model_name,


### PR DESCRIPTION
When the usage data model was modified, one of the tables end up with a half way transition. This just fix the table to a consistent name.

This PR is not ideal since it does not include tests (I'm sorry). I'm envisioning some refactoring very soon, so I'll delay the tests to move faster.