### PR TITLE
Processing ordinance files - Async

### DIFF
--- a/crates/compass/src/scraper/source.rs
+++ b/crates/compass/src/scraper/source.rs
@@ -206,7 +206,7 @@ impl Source {
         let mut walker = tokio::fs::read_dir(&path).await?;
         let mut jobs = tokio::task::JoinSet::new();
         while let Some(entry) = walker.next_entry().await? {
-            debug!("Processing: {:?}", entry);
+            trace!("Spawning job for entry: {:?}", entry.path());
             jobs.spawn(async move { File::new(entry.path()).await });
         }
         trace!("Waiting for all jobs to complete");
@@ -325,7 +325,7 @@ struct File {
 
 impl File {
     async fn new<P: AsRef<std::path::Path> + std::fmt::Debug>(path: P) -> Result<Self> {
-        trace!("Processing ordinance file: {:?}", path.as_ref());
+        debug!("Processing ordinance file: {:?}", path.as_ref());
 
         let metadata = tokio::fs::metadata(&path).await?;
         if !metadata.is_file() {

--- a/crates/compass/src/scraper/source.rs
+++ b/crates/compass/src/scraper/source.rs
@@ -206,12 +206,12 @@ impl Source {
         let mut walker = tokio::fs::read_dir(&path).await?;
         let mut jobs = tokio::task::JoinSet::new();
         while let Some(entry) = walker.next_entry().await? {
-            debug!("Spawning task for entry: {:?}", entry);
+            debug!("Processing: {:?}", entry);
             jobs.spawn(async move { File::new(entry.path()).await });
         }
-        debug!("Waiting for all jobs to complete");
+        trace!("Waiting for all jobs to complete");
         let inventory = jobs.join_all().await;
-        debug!("Inventory of files: {:?}", inventory);
+        trace!("Inventory of files: {:?}", inventory);
         debug!("Found a total of {} source documents", inventory.len());
 
         for file in inventory {
@@ -219,7 +219,7 @@ impl Source {
                 Ok(file) => {
                     let (file_name, checksum) = (file.filename, file.checksum);
                     if known_sources.contains(&(file_name, checksum)) {
-                        debug!("File {:?} matches known jurisdiction source", file.path);
+                        trace!("File {:?} matches known jurisdiction source", file.path);
                     } else {
                         warn!("File {:?} doesn't match known sources", file.path);
                     }


### PR DESCRIPTION
This is part of a few PRs to take effective advantage of async. Isolating in small parts to make it easier to review.

This PR just process the actual ordinance files asynchronously. Note the use of `spawn` to allow better use of multiple threads, if available.