### PR TITLE
fix, cfg: Correct COMPASS version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer


### PR DESCRIPTION
It needs the tags and git history to determine correct version built for the docker container.