### PR TITLE
Only deploy documentation for full version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build Docs
         # Make documentation with warnings as errors.
+        # The stricter Sphinx options below are currently disabled due to known documentation warnings.
+        # Once all warnings are resolved, consider enabling this line to catch documentation issues early.
         # run: SPHINXOPTS="-W --keep-going -n" pixi run -e pdoc make-html
         run: pixi run -e pdoc make-html
 


### PR DESCRIPTION
This PR resolves the issue of dev versions on the official public documentation. It now runs on PRs to keep track if we break the documentation, but only push on full versions.