### PR TITLE
Add unit tests for parsing module

### DIFF
--- a/tests/python/unit/utilities/test_utilities_parsing.py
+++ b/tests/python/unit/utilities/test_utilities_parsing.py
@@ -29,6 +29,7 @@ from compass.exceptions import COMPASSValueError
         ("```\ncode\n```", "code\n"),
         ("  ```json\ncode```  ", "json\ncode"),
         ("\n```\ncode\n```\n", "code\n"),
+        ("\r\n```\r\ncode\r\n```\r\n", "\r\ncode\r\n"),
         ("```", ""),
     ],
 )


### PR DESCRIPTION
## Pull Request Overview

This PR adds comprehensive test coverage for COMPASS parsing utilities and updates the CI workflow to trigger on test file changes.

- Adds extensive test coverage for parsing utility functions including LLM response cleaning, ordinance counting, and config loading
- Fixes test function naming (renamed from `test_sync_retry` to `test_llm_response_as_json`)
- Updates CI workflow to trigger on changes to test files

### Reviewed Changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated no comments.

| File | Description |
| ---- | ----------- |
| tests/python/unit/utilities/test_utilities_parsing.py | Adds comprehensive test coverage for parsing utilities including `clean_backticks_from_llm_response`, `extract_ord_year_from_doc_attrs`, `num_ordinances_in_doc`, `num_ordinances_dataframe`, `ordinances_bool_index`, and `load_config` functions. Also corrects the test function name from `test_sync_retry` to `test_llm_response_as_json`. |
| .github/workflows/ci-python.yml | Updates CI workflow triggers to include `tests/**` path, ensuring CI runs when test files are modified |