### PR TITLE
Docker build now only runs on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ "main" ]
   release:
-    types: [created, published]
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Install the cosign tool except on PR
+      # Install the cosign tool if planning to release
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v')
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      # Login against a Docker registry except on PR
+      # Login against a Docker registry if planning to release
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: startsWith(github.ref, 'refs/tags/v')
@@ -82,7 +82,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
+      # Sign the resulting Docker image digest if planning to release.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish
       # transparency data even for private images, pass --force to cosign below.


### PR DESCRIPTION
Now that the docker image is more stable, let's only create images on release. This stabilizes things for any potential concurrent runs and allows development to continue without compromising the integrity of ongoing processing. 