### PR TITLE
Error handling source from json

### DIFF
--- a/crates/compass/src/scraper/source.rs
+++ b/crates/compass/src/scraper/source.rs
@@ -151,14 +151,14 @@ impl Source {
     }
 
     fn from_json(content: &str) -> Result<Self> {
-        trace!("Parsing sources from json: {:?}", content);
+        trace!("Parsing sources' jurisdictions from json: {:?}", content);
 
         let source = match serde_json::from_str(content) {
             Ok(source) => source,
             Err(e) => {
-                error!("Error parsing sources from json: {:?}", e);
+                error!("Error parsing sources' jurisdictions from json: {:?}", e);
                 return Err(crate::error::Error::Undefined(
-                    "Failed to parse source's json".to_string(),
+                    "Failed to parse sources' jurisdiction as a json".to_string(),
                 ));
             }
         };


### PR DESCRIPTION
The DB loading was failing and there were no useful logs to help to speed up the response. I added more informative logs and also changed the expected data type for Jurisdiction's county in the source section. I previously assumed that it was always available, but now it is an `Option<>`, so it can take `Null` values.