### PR TITLE
Recording runtime logs in DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "chrono",
  "csv",
  "duckdb",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -777,6 +778,7 @@ dependencies = [
 name = "infra-compass-db"
 version = "0.0.8"
 dependencies = [
+ "chrono",
  "csv",
  "duckdb",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4.5.40", features = ["cargo"] }
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
 csv = { version = "1.3.1" }
 duckdb = { version = "1.4.0", features = ["bundled"] }
+regex = { version = "1.12.2" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }
 sha2 = { version = "0.10.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ keywords = ["NLR", "database", "energy", "ordinance"]
 infra-compass-db = { version = "0.0.8", path = "crates/compass" }
 anyhow = { version = "1.0.98" }
 clap = { version = "4.5.40", features = ["cargo"] }
+chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
 csv = { version = "1.3.1" }
 duckdb = { version = "1.4.0", features = ["bundled"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/compass/Cargo.toml
+++ b/crates/compass/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 csv = { workspace = true }
 duckdb.workspace = true
 serde.workspace = true

--- a/crates/compass/Cargo.toml
+++ b/crates/compass/Cargo.toml
@@ -15,6 +15,7 @@ keywords.workspace = true
 chrono = { workspace = true }
 csv = { workspace = true }
 duckdb.workspace = true
+regex = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2 = { workspace = true }

--- a/crates/compass/src/error.rs
+++ b/crates/compass/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
     #[error(transparent)]
     DuckDB(#[from] duckdb::Error),
 
+    #[error(transparent)]
+    Regex(#[from] regex::Error),
+
     #[allow(dead_code)]
     #[error("Undefined error")]
     // Used during development while it is not clear a category of error

--- a/crates/compass/src/lib.rs
+++ b/crates/compass/src/lib.rs
@@ -118,7 +118,7 @@ pub fn load_ordinance<P: AsRef<std::path::Path> + std::fmt::Debug>(
 
     let ordinance = runtime
         .block_on(scraper::ScrapedOrdinance::open(ordinance_path))
-        .unwrap();
+        .expect("Failed to open ordinance data source");
     conn.commit().unwrap();
     tracing::debug!("Transaction committed");
 

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -125,8 +125,9 @@ mod tests {
     }
 }
 
-struct LogRecord {
-    timestamp: String,
+#[derive(Debug)]
+pub(super) struct LogRecord {
+    timestamp: NaiveDateTime,
     level: LogLevel,
     subject: String,
     message: String,
@@ -201,7 +202,7 @@ mod tests {
 }
 
 impl LogRecord {
-    fn init_db(conn: &duckdb::Transaction) -> Result<()> {
+    pub(super) fn init_db(conn: &duckdb::Transaction) -> Result<()> {
         conn.execute_batch(
             r"
             CREATE SEQUENCE IF NOT EXISTS scrapper_log_seq START 1;

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -267,11 +267,12 @@ pub(crate) mod sample {
     use std::io::Write;
 
     pub(crate) fn as_text_v1() -> String {
-        r#"[2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS version 0.11.3.dev8+g69a75b7.d20251111
-        [2025-12-06 15:15:14,872] INFO - Task-1: Processing 250 jurisdiction(s)
-        [2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS
-        [2025-12-06 15:15:14,572] INFO - Jefferson County, Colorado: Running COMPASS
-        [2025-12-06 19:48:10,503] INFO - Task-1: Total runtime: 4:32:55
+        r#"
+[2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS version 0.11.3.dev8+g69a75b7.d20251111
+[2025-12-06 15:15:14,872] INFO - Task-1: Processing 250 jurisdiction(s)
+[2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS
+[2025-12-06 15:15:14,572] INFO - Jefferson County, Colorado: Running COMPASS
+[2025-12-06 19:48:10,503] INFO - Task-1: Total runtime: 4:32:55
         "#
         .to_string()
     }

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -1,0 +1,133 @@
+//! Runtime logs
+//!
+//! Parse and record the logs emitted by the runtime to support
+//! pos-processing and analysis.
+
+#[derive(Debug, serde::Deserialize)]
+enum LogLevel {
+    #[serde(rename = "TRACE")]
+    Trace,
+    #[serde(rename = "DEBUG")]
+    Debug,
+    #[serde(rename = "INFO")]
+    Info,
+    #[serde(rename = "WARNING")]
+    Warning,
+    #[serde(rename = "ERROR")]
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_deserialize_trace() {
+        let json = r#""TRACE""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Trace));
+    }
+
+    #[test]
+    fn test_deserialize_debug() {
+        let json = r#""DEBUG""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_deserialize_info() {
+        let json = r#""INFO""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Info));
+    }
+
+    #[test]
+    fn test_deserialize_warning() {
+        let json = r#""WARNING""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Warning));
+    }
+
+    #[test]
+    fn test_deserialize_error() {
+        let json = r#""ERROR""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Error));
+    }
+
+    #[test]
+    fn test_deserialize_invalid_variant() {
+        let json = r#""INVALID""#;
+        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_lowercase_fails() {
+        let json = r#""trace""#;
+        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_mixed_case_fails() {
+        let json = r#""Trace""#;
+        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_in_struct() {
+        #[derive(serde::Deserialize)]
+        struct LogEntry {
+            level: LogLevel,
+            message: String,
+        }
+
+        let json = r#"{"level": "ERROR", "message": "Something went wrong"}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert!(matches!(entry.level, LogLevel::Error));
+        assert_eq!(entry.message, "Something went wrong");
+    }
+
+    #[test]
+    fn test_deserialize_array_of_levels() {
+        let json = r#"["TRACE", "INFO", "ERROR"]"#;
+        let levels: Vec<LogLevel> = serde_json::from_str(json).unwrap();
+        assert_eq!(levels.len(), 3);
+        assert!(matches!(levels[0], LogLevel::Trace));
+        assert!(matches!(levels[1], LogLevel::Info));
+        assert!(matches!(levels[2], LogLevel::Error));
+    }
+
+    #[test]
+    fn test_deserialize_with_whitespace() {
+        let json = r#"  "INFO"  "#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Info));
+    }
+
+    #[test]
+    fn test_error_message_contains_valid_options() {
+        let json = r#""FATAL""#;
+        let result: Result<LogLevel, _> = serde_json::from_str(json);
+
+        match result {
+            Err(e) => {
+                let error_msg = e.to_string();
+                // The error message should mention valid variants
+                assert!(error_msg.contains("unknown variant"));
+            }
+            Ok(_) => panic!("Expected deserialization to fail"),
+        }
+    }
+}
+
+struct LogRecord {
+    timestamp: String,
+    level: LogLevel,
+    subject: String,
+    message: String,
+}

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -284,6 +284,17 @@ impl RuntimeLogs {
         let records = Self::parse(&content)?;
         Ok(records)
     }
+
+    pub(super) fn record(&self, conn: &duckdb::Transaction, commit_id: usize) -> Result<()> {
+        // debug!("Recording log: {:?}", self);
+        debug!("Recording runtime logs");
+
+        for record in &self.0 {
+            record.record(conn, commit_id)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -174,6 +174,21 @@ impl LogRecord {
             message,
         })
     }
+
+    fn record(&self, conn: &duckdb::Transaction, bookkeeper_id: usize) -> Result<()> {
+        trace!("Recording log record: {:?}", self);
+        conn.execute(
+            "INSERT INTO logs (bookkeeper_lnk, timestamp, level, subject, message) VALUES (?, ?, ?, ?, ?)",
+            duckdb::params![
+                bookkeeper_id,
+                self.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+                format!("{:?}", self.level),
+                &self.subject,
+                &self.message,
+            ],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -232,3 +232,26 @@ impl LogRecord {
         Ok(records)
     }
 }
+
+#[cfg(test)]
+/// Samples of runtime logs for testing purposes
+pub(crate) mod sample {
+    use crate::error::Result;
+    use std::io::Write;
+
+    pub(crate) fn as_text_v1() -> String {
+        r#"[2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS version 0.11.3.dev8+g69a75b7.d20251111
+        [2025-12-06 15:15:14,872] INFO - Task-1: Processing 250 jurisdiction(s)
+        [2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS
+        [2025-12-06 19:48:10,503] INFO - Task-1: Total runtime: 4:32:55
+        "#
+        .to_string()
+    }
+
+    pub(crate) fn as_file<P: AsRef<std::path::Path>>(path: P) -> Result<std::fs::File> {
+        let mut file = std::fs::File::create(path).unwrap();
+        dbg!(&file);
+        writeln!(file, "{}", as_text_v1()).unwrap();
+        Ok(file)
+    }
+}

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -12,6 +12,8 @@ use crate::error::Result;
 
 #[derive(Debug, PartialEq, serde::Deserialize)]
 enum LogLevel {
+    #[serde(rename = "DEBUG_TO_FILE")]
+    DebugToFile,
     #[serde(rename = "TRACE")]
     Trace,
     #[serde(rename = "DEBUG")]

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -199,3 +199,21 @@ mod tests {
         assert_eq!(record.message, "Running COMPASS");
     }
 }
+
+impl LogRecord {
+    fn init_db(conn: &duckdb::Transaction) -> Result<()> {
+        conn.execute_batch(
+            r"
+            CREATE SEQUENCE IF NOT EXISTS scrapper_log_seq START 1;
+            CREATE TABLE IF NOT EXISTS logs (
+              id INTEGER PRIMARY KEY DEFAULT NEXTVAL('scrapper_log_seq'),
+              timestamp TIMESTAMP,
+              level VARCHAR,
+              subject VARCHAR,
+              message VARCHAR
+            );
+            ",
+        )?;
+        Ok(())
+    }
+}

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -176,7 +176,8 @@ impl LogRecord {
     fn parse_lines(input: &str) -> Result<Vec<Self>> {
         input
             .lines()
-            .filter(|line| !line.trim().is_empty())
+            .map(|line| line.trim())
+            .filter(|line| !line.is_empty())
             .map(Self::parse)
             .collect()
     }

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -4,7 +4,6 @@
 //! pos-processing and analysis.
 
 use chrono::NaiveDateTime;
-use duckdb;
 use regex::Regex;
 use tracing::{debug, trace};
 
@@ -29,7 +28,6 @@ enum LogLevel {
 #[cfg(test)]
 mod test_loglevel {
     use super::*;
-    use serde_json;
 
     #[test]
     fn deserialize_trace() {

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -23,68 +23,68 @@ enum LogLevel {
 }
 
 #[cfg(test)]
-mod tests {
+mod test_loglevel {
     use super::*;
     use serde_json;
 
     #[test]
-    fn test_deserialize_trace() {
+    fn deserialize_trace() {
         let json = r#""TRACE""#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert!(matches!(level, LogLevel::Trace));
     }
 
     #[test]
-    fn test_deserialize_debug() {
+    fn deserialize_debug() {
         let json = r#""DEBUG""#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert!(matches!(level, LogLevel::Debug));
     }
 
     #[test]
-    fn test_deserialize_info() {
+    fn deserialize_info() {
         let json = r#""INFO""#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert!(matches!(level, LogLevel::Info));
     }
 
     #[test]
-    fn test_deserialize_warning() {
+    fn deserialize_warning() {
         let json = r#""WARNING""#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert!(matches!(level, LogLevel::Warning));
     }
 
     #[test]
-    fn test_deserialize_error() {
+    fn deserialize_error() {
         let json = r#""ERROR""#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert!(matches!(level, LogLevel::Error));
     }
 
     #[test]
-    fn test_deserialize_invalid_variant() {
+    fn deserialize_invalid_variant() {
         let json = r#""INVALID""#;
-        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_deserialize_lowercase_fails() {
+    fn deserialize_lowercase_fails() {
         let json = r#""trace""#;
-        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_deserialize_mixed_case_fails() {
+    fn deserialize_mixed_case_fails() {
         let json = r#""Trace""#;
-        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_deserialize_in_struct() {
+    fn deserialize_in_struct() {
         #[derive(serde::Deserialize)]
         struct LogEntry {
             level: LogLevel,
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_array_of_levels() {
+    fn deserialize_array_of_levels() {
         let json = r#"["TRACE", "INFO", "ERROR"]"#;
         let levels: Vec<LogLevel> = serde_json::from_str(json).unwrap();
         assert_eq!(levels.len(), 3);
@@ -108,16 +108,16 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_with_whitespace() {
+    fn deserialize_with_whitespace() {
         let json = r#"  "INFO"  "#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert!(matches!(level, LogLevel::Info));
     }
 
     #[test]
-    fn test_error_message_contains_valid_options() {
+    fn error_message_contains_valid_options() {
         let json = r#""FATAL""#;
-        let result: Result<LogLevel, _> = serde_json::from_str(json);
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
 
         match result {
             Err(e) => {

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -4,7 +4,9 @@
 //! pos-processing and analysis.
 
 use chrono::NaiveDateTime;
+use duckdb;
 use regex::Regex;
+use tracing::{debug, trace};
 
 use crate::error::Result;
 

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -223,4 +223,12 @@ impl LogRecord {
         )?;
         Ok(())
     }
+
+    pub(super) async fn open<P: AsRef<std::path::Path>>(root: P) -> Result<Vec<Self>> {
+        let path = root.as_ref().join("logs").join("all.log");
+        dbg!(&path);
+        let content = tokio::fs::read_to_string(path).await?;
+        let records = Self::parse_lines(&content)?;
+        Ok(records)
+    }
 }

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -235,6 +235,7 @@ impl RuntimeLogs {
             CREATE SEQUENCE IF NOT EXISTS scrapper_log_seq START 1;
             CREATE TABLE IF NOT EXISTS logs (
               id INTEGER PRIMARY KEY DEFAULT NEXTVAL('scrapper_log_seq'),
+              bookkeeper_lnk INTEGER REFERENCES bookkeeper(id) NOT NULL,
               timestamp TIMESTAMP,
               level VARCHAR,
               subject VARCHAR,

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -142,12 +142,15 @@ pub(super) struct LogRecord {
     message: String,
 }
 
+use std::sync::LazyLock;
+
 impl LogRecord {
     fn parse(line: &str) -> Result<Self> {
         // Regex pattern: [timestamp] LEVEL - subject: message
-        let re = Regex::new(r"^\[([^\]]+)\]\s+(\w+)\s+-\s+([^:]+):\s+(.+)$").unwrap();
+        static RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\[([^\]]+)\]\s+(\w+)\s+-\s+([^:]+):\s+(.+)$").unwrap());
 
-        let caps = re.captures(line).ok_or_else(|| {
+        let caps = RE.captures(line).ok_or_else(|| {
             crate::error::Error::Undefined(format!("Failed to parse log line: {}", line))
         })?;
 

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -175,3 +175,27 @@ impl LogRecord {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_line() {
+        let line = "[2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS";
+        let record = LogRecord::parse(line).unwrap();
+
+        assert_eq!(
+            record.timestamp.date(),
+            chrono::NaiveDate::from_ymd_opt(2025, 12, 6).unwrap()
+        );
+        assert_eq!(
+            record.timestamp.time(),
+            chrono::NaiveTime::from_hms_milli_opt(15, 15, 14, 272).unwrap()
+        );
+
+        assert!(matches!(record.level, LogLevel::Info));
+        assert_eq!(record.subject, "Task-1");
+        assert_eq!(record.message, "Running COMPASS");
+    }
+}

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -224,6 +224,15 @@ mod tests {
 pub(super) struct RuntimeLogs(Vec<LogRecord>);
 
 impl RuntimeLogs {
+    /// Parse runtime logs from text input
+    ///
+    /// # Notes
+    /// - For now, hardcoded to only keep INFO, WARNING, and ERROR levels.
+    ///   These logs are quite long with the more verbose levels. Since I
+    ///   collect everything, it is better to filter and reduce it here.
+    ///   In the future, consider returning an iterator instead.
+    /// - Ignore mulltiple lines messages.
+    /// - Lines that fail to parse are skipped with a warning.
     fn parse(input: &str) -> Result<Self> {
         let records: Vec<LogRecord> = input
             .lines()

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -3,7 +3,12 @@
 //! Parse and record the logs emitted by the runtime to support
 //! pos-processing and analysis.
 
-#[derive(Debug, serde::Deserialize)]
+use chrono::NaiveDateTime;
+use regex::Regex;
+
+use crate::error::Result;
+
+#[derive(Debug, PartialEq, serde::Deserialize)]
 enum LogLevel {
     #[serde(rename = "TRACE")]
     Trace,

--- a/crates/compass/src/scraper/log.rs
+++ b/crates/compass/src/scraper/log.rs
@@ -243,6 +243,7 @@ pub(crate) mod sample {
         r#"[2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS version 0.11.3.dev8+g69a75b7.d20251111
         [2025-12-06 15:15:14,872] INFO - Task-1: Processing 250 jurisdiction(s)
         [2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS
+        [2025-12-06 15:15:14,572] INFO - Jefferson County, Colorado: Running COMPASS
         [2025-12-06 19:48:10,503] INFO - Task-1: Total runtime: 4:32:55
         "#
         .to_string()

--- a/crates/compass/src/scraper/log/loglevel.rs
+++ b/crates/compass/src/scraper/log/loglevel.rs
@@ -1,0 +1,133 @@
+//! Runtime logs
+//!
+//! Parse and record the logs emitted by the runtime to support
+//! pos-processing and analysis.
+
+use chrono::NaiveDateTime;
+use regex::Regex;
+use tracing::{debug, trace};
+
+use crate::error::Result;
+
+#[derive(Debug, PartialEq, serde::Deserialize)]
+pub(super) enum LogLevel {
+    #[serde(rename = "DEBUG_TO_FILE")]
+    DebugToFile,
+    #[serde(rename = "TRACE")]
+    Trace,
+    #[serde(rename = "DEBUG")]
+    Debug,
+    #[serde(rename = "INFO")]
+    Info,
+    #[serde(rename = "WARNING")]
+    Warning,
+    #[serde(rename = "ERROR")]
+    Error,
+}
+
+#[cfg(test)]
+mod test_loglevel {
+    use super::*;
+
+    #[test]
+    fn deserialize_trace() {
+        let json = r#""TRACE""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Trace));
+    }
+
+    #[test]
+    fn deserialize_debug() {
+        let json = r#""DEBUG""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Debug));
+    }
+
+    #[test]
+    fn deserialize_info() {
+        let json = r#""INFO""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Info));
+    }
+
+    #[test]
+    fn deserialize_warning() {
+        let json = r#""WARNING""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Warning));
+    }
+
+    #[test]
+    fn deserialize_error() {
+        let json = r#""ERROR""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Error));
+    }
+
+    #[test]
+    fn deserialize_invalid_variant() {
+        let json = r#""INVALID""#;
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_lowercase_fails() {
+        let json = r#""trace""#;
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_mixed_case_fails() {
+        let json = r#""Trace""#;
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_in_struct() {
+        #[derive(serde::Deserialize)]
+        struct LogEntry {
+            level: LogLevel,
+            message: String,
+        }
+
+        let json = r#"{"level": "ERROR", "message": "Something went wrong"}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert!(matches!(entry.level, LogLevel::Error));
+        assert_eq!(entry.message, "Something went wrong");
+    }
+
+    #[test]
+    fn deserialize_array_of_levels() {
+        let json = r#"["TRACE", "INFO", "ERROR"]"#;
+        let levels: Vec<LogLevel> = serde_json::from_str(json).unwrap();
+        assert_eq!(levels.len(), 3);
+        assert!(matches!(levels[0], LogLevel::Trace));
+        assert!(matches!(levels[1], LogLevel::Info));
+        assert!(matches!(levels[2], LogLevel::Error));
+    }
+
+    #[test]
+    fn deserialize_with_whitespace() {
+        let json = r#"  "INFO"  "#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert!(matches!(level, LogLevel::Info));
+    }
+
+    #[test]
+    fn error_message_contains_valid_options() {
+        let json = r#""FATAL""#;
+        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
+
+        match result {
+            Err(e) => {
+                let error_msg = e.to_string();
+                // The error message should mention valid variants
+                assert!(error_msg.contains("unknown variant"));
+            }
+            Ok(_) => panic!("Expected deserialization to fail"),
+        }
+    }
+}

--- a/crates/compass/src/scraper/log/loglevel.rs
+++ b/crates/compass/src/scraper/log/loglevel.rs
@@ -3,12 +3,7 @@
 //! Parse and record the logs emitted by the runtime to support
 //! pos-processing and analysis.
 
-use chrono::NaiveDateTime;
-use regex::Regex;
-use tracing::{debug, trace};
-
-use crate::error::Result;
-
+/// Log levels emitted by the (Python) runtime.
 #[derive(Debug, PartialEq, serde::Deserialize)]
 pub(super) enum LogLevel {
     #[serde(rename = "DEBUG_TO_FILE")]

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -158,9 +158,9 @@ impl RuntimeLogs {
     pub(super) fn init_db(conn: &duckdb::Transaction) -> Result<()> {
         conn.execute_batch(
             r"
-            CREATE SEQUENCE IF NOT EXISTS scrapper_log_seq START 1;
+            CREATE SEQUENCE IF NOT EXISTS scraper_log_seq START 1;
             CREATE TABLE IF NOT EXISTS logs (
-              id INTEGER PRIMARY KEY DEFAULT NEXTVAL('scrapper_log_seq'),
+              id INTEGER PRIMARY KEY DEFAULT NEXTVAL('scraper_log_seq'),
               bookkeeper_lnk INTEGER REFERENCES bookkeeper(id) NOT NULL,
               timestamp TIMESTAMP,
               level VARCHAR,

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -80,7 +80,7 @@ impl LogRecord {
             "INSERT INTO logs (bookkeeper_lnk, timestamp, level, subject, message) VALUES (?, ?, ?, ?, ?)",
             duckdb::params![
                 bookkeeper_id,
-                self.timestamp.format("%Y-%m-%d %H:%M:%S,%3f").to_string(),
+                self.timestamp.format("%Y-%m-%d %H:%M:%S.%3f").to_string(),
                 format!("{:?}", self.level),
                 &self.subject,
                 &self.message,

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -1,13 +1,13 @@
 //! Runtime logs
 //!
 //! Parse and record the logs from the ordinance runtime to support
-//! pos-processing and analysis.
+//! post-processing and analysis.
 //!
 //! The most verbose levels are ignored to minimize the impact on the
 //! final database size. The outputs are archived, so any forensics
 //! can be done by inspecting the raw log files if needed. The purpose
 //! here is to support questions such as what is the distribution of
-//! cost and runtime per jurisdictions? Which exceptions where captured
+//! cost and runtime per jurisdictions? Which exceptions were captured
 //! on each jurisdiction?
 
 mod loglevel;

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -16,7 +16,7 @@ use std::sync::LazyLock;
 
 use chrono::NaiveDateTime;
 use regex::Regex;
-use tracing::{debug, trace};
+use tracing::{debug, error, trace};
 
 use crate::error::Result;
 use loglevel::LogLevel;
@@ -49,8 +49,10 @@ impl LogRecord {
         })?;
 
         let timestamp_str = caps.get(1).unwrap().as_str().to_string();
+        trace!("Parsing timestamp: {}", timestamp_str);
         let timestamp = NaiveDateTime::parse_from_str(&timestamp_str, "%Y-%m-%d %H:%M:%S,%3f")
             .map_err(|e| {
+                error!("Failed to parse timestamp: {}, error: {}", timestamp_str, e);
                 crate::error::Error::Undefined(format!(
                     "Failed to parse timestamp '{}': {}",
                     timestamp_str, e

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -59,9 +59,9 @@ impl LogRecord {
 
         let level_str = caps.get(2).unwrap().as_str();
         // Parse the log level
-        let level = serde_json::from_str(&format!(r#""{}""#, level_str))
-            .map_err(|e| format!("Invalid log level '{}': {}", level_str, e))
-            .unwrap();
+        let level = serde_json::from_str(&format!(r#""{}""#, level_str)).map_err(|e| {
+            crate::error::Error::Undefined(format!("Invalid log level '{}': {}", level_str, e))
+        })?;
 
         let subject = caps.get(3).unwrap().as_str().to_string();
         let message = caps.get(4).unwrap().as_str().to_string();

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -29,7 +29,7 @@ use loglevel::LogLevel;
 /// or
 /// [2025-12-06 15:15:14,572] INFO - Jefferson County, Colorado: Running COMPASS
 ///
-/// Note that the 'message' can have multiple lines.
+/// The 'message' field only supports single-line log messages.
 pub(super) struct LogRecord {
     timestamp: NaiveDateTime,
     level: LogLevel,

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -1,7 +1,14 @@
 //! Runtime logs
 //!
-//! Parse and record the logs emitted by the runtime to support
+//! Parse and record the logs from the ordinance runtime to support
 //! pos-processing and analysis.
+//!
+//! The most verbose levels are ignored to minimize the impact on the
+//! final database size. The outputs are archived, so any forensics
+//! can be done by inspecting the raw log files if needed. The purpose
+//! here is to support questions such as what is the distribution of
+//! cost and runtime per jurisdictions? Which exceptions where captured
+//! on each jurisdiction?
 
 mod loglevel;
 
@@ -15,6 +22,14 @@ use crate::error::Result;
 use loglevel::LogLevel;
 
 #[derive(Debug)]
+/// A single log record parsed from the runtime logs.
+///
+/// Expect something like:
+/// [2025-12-06 15:15:14,272] INFO - Task-1: Running COMPASS
+/// or
+/// [2025-12-06 15:15:14,572] INFO - Jefferson County, Colorado: Running COMPASS
+///
+/// Note that the 'message' can have multiple lines.
 pub(super) struct LogRecord {
     timestamp: NaiveDateTime,
     level: LogLevel,
@@ -23,6 +38,7 @@ pub(super) struct LogRecord {
 }
 
 impl LogRecord {
+    /// Parse a single log line into a LogRecord
     fn parse(line: &str) -> Result<Self> {
         // Regex pattern: [timestamp] LEVEL - subject: message
         static RE: LazyLock<Regex> =
@@ -99,6 +115,7 @@ mod tests {
 }
 
 #[derive(Debug)]
+/// Collection of runtime log records
 pub(super) struct RuntimeLogs(Vec<LogRecord>);
 
 impl RuntimeLogs {

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -80,7 +80,7 @@ impl LogRecord {
             "INSERT INTO logs (bookkeeper_lnk, timestamp, level, subject, message) VALUES (?, ?, ?, ?, ?)",
             duckdb::params![
                 bookkeeper_id,
-                self.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+                self.timestamp.format("%Y-%m-%d %H:%M:%S,%3f").to_string(),
                 format!("{:?}", self.level),
                 &self.subject,
                 &self.message,

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -210,7 +210,6 @@ pub(crate) mod sample {
 
     pub(crate) fn as_file<P: AsRef<std::path::Path>>(path: P) -> Result<std::fs::File> {
         let mut file = std::fs::File::create(path).unwrap();
-        dbg!(&file);
         writeln!(file, "{}", as_text_v1()).unwrap();
         Ok(file)
     }

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -174,7 +174,6 @@ impl RuntimeLogs {
 
     pub(super) async fn open<P: AsRef<std::path::Path>>(root: P) -> Result<Self> {
         let path = root.as_ref().join("logs").join("all.log");
-        dbg!(&path);
         let content = tokio::fs::read_to_string(path).await?;
         let records = Self::parse(&content)?;
         Ok(records)

--- a/crates/compass/src/scraper/log/mod.rs
+++ b/crates/compass/src/scraper/log/mod.rs
@@ -3,134 +3,16 @@
 //! Parse and record the logs emitted by the runtime to support
 //! pos-processing and analysis.
 
+mod loglevel;
+
+use std::sync::LazyLock;
+
 use chrono::NaiveDateTime;
 use regex::Regex;
 use tracing::{debug, trace};
 
 use crate::error::Result;
-
-#[derive(Debug, PartialEq, serde::Deserialize)]
-enum LogLevel {
-    #[serde(rename = "DEBUG_TO_FILE")]
-    DebugToFile,
-    #[serde(rename = "TRACE")]
-    Trace,
-    #[serde(rename = "DEBUG")]
-    Debug,
-    #[serde(rename = "INFO")]
-    Info,
-    #[serde(rename = "WARNING")]
-    Warning,
-    #[serde(rename = "ERROR")]
-    Error,
-}
-
-#[cfg(test)]
-mod test_loglevel {
-    use super::*;
-
-    #[test]
-    fn deserialize_trace() {
-        let json = r#""TRACE""#;
-        let level: LogLevel = serde_json::from_str(json).unwrap();
-        assert!(matches!(level, LogLevel::Trace));
-    }
-
-    #[test]
-    fn deserialize_debug() {
-        let json = r#""DEBUG""#;
-        let level: LogLevel = serde_json::from_str(json).unwrap();
-        assert!(matches!(level, LogLevel::Debug));
-    }
-
-    #[test]
-    fn deserialize_info() {
-        let json = r#""INFO""#;
-        let level: LogLevel = serde_json::from_str(json).unwrap();
-        assert!(matches!(level, LogLevel::Info));
-    }
-
-    #[test]
-    fn deserialize_warning() {
-        let json = r#""WARNING""#;
-        let level: LogLevel = serde_json::from_str(json).unwrap();
-        assert!(matches!(level, LogLevel::Warning));
-    }
-
-    #[test]
-    fn deserialize_error() {
-        let json = r#""ERROR""#;
-        let level: LogLevel = serde_json::from_str(json).unwrap();
-        assert!(matches!(level, LogLevel::Error));
-    }
-
-    #[test]
-    fn deserialize_invalid_variant() {
-        let json = r#""INVALID""#;
-        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn deserialize_lowercase_fails() {
-        let json = r#""trace""#;
-        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn deserialize_mixed_case_fails() {
-        let json = r#""Trace""#;
-        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn deserialize_in_struct() {
-        #[derive(serde::Deserialize)]
-        struct LogEntry {
-            level: LogLevel,
-            message: String,
-        }
-
-        let json = r#"{"level": "ERROR", "message": "Something went wrong"}"#;
-        let entry: LogEntry = serde_json::from_str(json).unwrap();
-        assert!(matches!(entry.level, LogLevel::Error));
-        assert_eq!(entry.message, "Something went wrong");
-    }
-
-    #[test]
-    fn deserialize_array_of_levels() {
-        let json = r#"["TRACE", "INFO", "ERROR"]"#;
-        let levels: Vec<LogLevel> = serde_json::from_str(json).unwrap();
-        assert_eq!(levels.len(), 3);
-        assert!(matches!(levels[0], LogLevel::Trace));
-        assert!(matches!(levels[1], LogLevel::Info));
-        assert!(matches!(levels[2], LogLevel::Error));
-    }
-
-    #[test]
-    fn deserialize_with_whitespace() {
-        let json = r#"  "INFO"  "#;
-        let level: LogLevel = serde_json::from_str(json).unwrap();
-        assert!(matches!(level, LogLevel::Info));
-    }
-
-    #[test]
-    fn error_message_contains_valid_options() {
-        let json = r#""FATAL""#;
-        let result: std::result::Result<LogLevel, _> = serde_json::from_str(json);
-
-        match result {
-            Err(e) => {
-                let error_msg = e.to_string();
-                // The error message should mention valid variants
-                assert!(error_msg.contains("unknown variant"));
-            }
-            Ok(_) => panic!("Expected deserialization to fail"),
-        }
-    }
-}
+use loglevel::LogLevel;
 
 #[derive(Debug)]
 pub(super) struct LogRecord {
@@ -139,8 +21,6 @@ pub(super) struct LogRecord {
     subject: String,
     message: String,
 }
-
-use std::sync::LazyLock;
 
 impl LogRecord {
     fn parse(line: &str) -> Result<Self> {

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -150,6 +150,7 @@ impl ScrapedOrdinance {
         self.metadata.write(&conn, commit_id).unwrap();
         self.usage().await.unwrap().write(&conn, commit_id).unwrap();
         self.ordinance.write(&conn, commit_id).unwrap();
+        self.logs.record(&conn, commit_id).unwrap();
 
         tracing::trace!("Committing transaction");
         conn.commit()?;

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -206,7 +206,7 @@ mod tests {
 
         let _metadata_file = metadata::sample::as_file(target.path().join("meta.json")).unwrap();
         let _usage_file = usage::sample::as_file(target.path().join("usage.json")).unwrap();
-        std::fs::create_dir(&target.path().join("logs")).unwrap();
+        std::fs::create_dir(target.path().join("logs")).unwrap();
         let _log_file = log::sample::as_file(target.path().join("logs").join("all.log")).unwrap();
         ordinance::sample::as_file(target.path()).unwrap();
 

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -1,5 +1,6 @@
 //! Support for the ordinance scraper output
 
+mod log;
 mod metadata;
 mod ordinance;
 mod source;
@@ -88,6 +89,7 @@ impl ScrapedOrdinance {
     pub(super) fn init_db(conn: &duckdb::Transaction) -> Result<()> {
         debug!("Initializing ScrapedOrdinance database");
 
+        log::LogRecord::init_db(conn)?;
         source::Source::init_db(conn)?;
         metadata::Metadata::init_db(conn)?;
         usage::Usage::init_db(conn)?;

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -12,6 +12,7 @@ use tracing::{self, debug, trace};
 
 use crate::error;
 use crate::error::Result;
+use log::RuntimeLogs;
 use metadata::Metadata;
 use ordinance::Ordinance;
 #[allow(unused_imports)]
@@ -74,6 +75,8 @@ pub(crate) struct ScrapedOrdinance {
     usage: Usage,
     /// The ordinance section
     ordinance: Ordinance,
+    /// The runtime logs
+    logs: RuntimeLogs,
 }
 
 impl ScrapedOrdinance {
@@ -89,7 +92,7 @@ impl ScrapedOrdinance {
     pub(super) fn init_db(conn: &duckdb::Transaction) -> Result<()> {
         debug!("Initializing ScrapedOrdinance database");
 
-        log::LogRecord::init_db(conn)?;
+        log::RuntimeLogs::init_db(conn)?;
         source::Source::init_db(conn)?;
         metadata::Metadata::init_db(conn)?;
         usage::Usage::init_db(conn)?;
@@ -119,7 +122,7 @@ impl ScrapedOrdinance {
             metadata::Metadata::open(&root),
             usage::Usage::open(&root),
             ordinance::Ordinance::open(&root),
-            log::LogRecord::open(&root),
+            log::RuntimeLogs::open(&root),
         )?;
         trace!("Scraped ordinance opened successfully");
 

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -176,11 +176,7 @@ impl ScrapedOrdinance {
 
 #[cfg(test)]
 mod tests {
-    use super::ScrapedOrdinance;
-    use super::metadata;
-    use super::ordinance;
-    use super::source;
-    use super::usage;
+    use super::*;
     use std::io::Write;
 
     #[tokio::test]

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -114,11 +114,12 @@ impl ScrapedOrdinance {
             return Err(error::Error::Undefined("Path does not exist".to_string()));
         }
 
-        let (source, metadata, usage, ordinance) = tokio::try_join!(
+        let (source, metadata, usage, ordinance, logs) = tokio::try_join!(
             source::Source::open(&root),
             metadata::Metadata::open(&root),
             usage::Usage::open(&root),
-            ordinance::Ordinance::open(&root)
+            ordinance::Ordinance::open(&root),
+            log::LogRecord::open(&root),
         )?;
         trace!("Scraped ordinance opened successfully");
 
@@ -129,6 +130,7 @@ impl ScrapedOrdinance {
             source,
             usage,
             ordinance,
+            logs,
         })
     }
 

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -207,6 +207,8 @@ mod tests {
 
         let _metadata_file = metadata::sample::as_file(target.path().join("meta.json")).unwrap();
         let _usage_file = usage::sample::as_file(target.path().join("usage.json")).unwrap();
+        std::fs::create_dir(&target.path().join("logs")).unwrap();
+        let _log_file = log::sample::as_file(target.path().join("logs").join("all.log")).unwrap();
         ordinance::sample::as_file(target.path()).unwrap();
 
         let demo = ScrapedOrdinance::open(target).await.unwrap();

--- a/crates/compass/src/scraper/mod.rs
+++ b/crates/compass/src/scraper/mod.rs
@@ -140,7 +140,7 @@ impl ScrapedOrdinance {
     #[allow(dead_code)]
     pub(crate) async fn push(&self, conn: &mut duckdb::Connection, commit_id: usize) -> Result<()> {
         // Load the ordinance into the database
-        tracing::trace!("Pushing scraped ordinance into the database");
+        tracing::info!("Recording scraped ordinance into the database");
         let conn = conn.transaction().unwrap();
         tracing::trace!("Transaction started");
 

--- a/crates/compass/src/scraper/usage.rs
+++ b/crates/compass/src/scraper/usage.rs
@@ -63,7 +63,7 @@ pub(super) struct UsageValues {
 impl Usage {
     /// Initialize the database for the Usage context
     pub(super) fn init_db(conn: &duckdb::Transaction) -> Result<()> {
-        tracing::trace!("Initializing database for Usage");
+        tracing::debug!("Initializing database for Usage");
         conn.execute_batch(
             r"
             CREATE SEQUENCE usage_sequence START 1;


### PR DESCRIPTION
Parse the runtime logs and record those in the DB to support pos-processing analysis.

The purpose here is to support statistics on cost per jurisdictions or easily identify exceptions in large batches.