### PR TITLE
Crawl4AI changed API

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -16700,8 +16700,8 @@ packages:
   timestamp: 1736252433366
 - pypi: ./
   name: infra-compass
-  version: 0.15.3.dev7+gdc47c81.d20260412
-  sha256: ec8f1321cae4f5116fad2cda5a16dfdede49a7acc651319734c6013d6fc5026c
+  version: 0.15.3.dev10+gef29098
+  sha256: eb5dc5c0df2360c67414fd36615a23a5a5030398e4650f89474f88f163f3783f
   requires_dist:
   - beautifulsoup4>=4.12.3,<5
   - click>=8.1.7,<9

--- a/pixi.lock
+++ b/pixi.lock
@@ -16700,8 +16700,8 @@ packages:
   timestamp: 1736252433366
 - pypi: ./
   name: infra-compass
-  version: 0.15.3.dev43+g6b44d198.d20260313
-  sha256: 28bc51640b48a1c841e9366c8c2562c159476f1e39364e28a7c5ab14d95c46fa
+  version: 0.15.3.dev7+gdc47c81.d20260412
+  sha256: ec8f1321cae4f5116fad2cda5a16dfdede49a7acc651319734c6013d6fc5026c
   requires_dist:
   - beautifulsoup4>=4.12.3,<5
   - click>=8.1.7,<9
@@ -16718,6 +16718,7 @@ packages:
   - playwright>=1.49.0,<1.52
   - pyjson5>=2.0.0,<3
   - rich>=13.9.4,<14
+  - crawl4ai>=0.8.0,<0.8.5
   - pytesseract>=0.3.13,<0.4 ; extra == 'ocr'
   - jupyter>=1.0.0,<1.1 ; extra == 'dev'
   - pipreqs>=0.4.13,<0.5 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "playwright>=1.49.0,<1.52",  # version range required for c4ai"
   "pyjson5>=2.0.0,<3",
   "rich>=13.9.4,<14",
-  "Crawl4AI>=0.8.0,<0.8.5", # Remove this once nlr-elm is updated
+  "crawl4ai>=0.8.0,<0.8.5", # Remove this once nlr-elm is updated
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "playwright>=1.49.0,<1.52",  # version range required for c4ai"
   "pyjson5>=2.0.0,<3",
   "rich>=13.9.4,<14",
+  "Crawl4AI>=0.8.0,<0.8.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "playwright>=1.49.0,<1.52",  # version range required for c4ai"
   "pyjson5>=2.0.0,<3",
   "rich>=13.9.4,<14",
-  "Crawl4AI>=0.8.0,<0.8.5",
+  "Crawl4AI>=0.8.0,<0.8.5", # Remove this once nlr-elm is updated
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We depend on ELM which depends on Crawl4AI. Crawl4AI-0.8.5 changed its API breaking compatibility. Let's hold on <0.8.5 until ELM is updated.

This PR will fix the recent failures in our Github-actions only for `tox` tasks since everything else relies on `pixi` thus have a well defined environment. Which is a real world argument for the recent discussions on keep using `tox` here.