### PR TITLE
Informing FIPS with jurisdiction name

### DIFF
--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -560,7 +560,10 @@ class _COMPASSRunner:
         if isinstance(known_local_docs, str):
             known_local_docs = load_config(known_local_docs)
         inventory = {int(key): val for key, val in known_local_docs.items()}
-        logger.trace("Loaded known local docs for FIPS codes: %s", list(inventory.keys()))
+        logger.trace(
+            "Loaded known local docs for FIPS codes: %s",
+            list(inventory.keys()),
+        )
         return inventory
 
     @cached_property

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -855,8 +855,9 @@ class _SingleJurisdictionRunner:
         start_time = time.monotonic()
         extraction_context = None
         logger.info(
-            "Kicking off processing for jurisdiction: %s",
+            "Kicking off processing for jurisdiction: %s (%s)",
             self.jurisdiction.full_name,
+            self.jurisdiction.code,
         )
         try:
             extraction_context = await self._run()

--- a/compass/scripts/process.py
+++ b/compass/scripts/process.py
@@ -559,7 +559,9 @@ class _COMPASSRunner:
         known_local_docs = self.process_kwargs.known_local_docs or {}
         if isinstance(known_local_docs, str):
             known_local_docs = load_config(known_local_docs)
-        return {int(key): val for key, val in known_local_docs.items()}
+        inventory = {int(key): val for key, val in known_local_docs.items()}
+        logger.trace("Loaded known local docs for FIPS codes: %s", list(inventory.keys()))
+        return inventory
 
     @cached_property
     def known_doc_urls(self):


### PR DESCRIPTION
Although we provide a list (CSV) of jurisdictions, when running with local files, the matching is done with FIPS. This will help to identify typos and other silly errors.