### PR TITLE
Updating docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/prefix-dev/pixi:0.50.2 AS build
+FROM ghcr.io/prefix-dev/pixi:0.68.1 AS build
 
 ARG PIXI_ENV=default
 


### PR DESCRIPTION
Latest pixi is required to parse v7 standard.