### PR TITLE
crawl4ai dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,4 @@ deps=
     pytest>=8.0
 
 [testenv:latest]
-description = (almost) no constraints, thus latest version of dependencies
-deps=
-    crawl4ai<=0.72.0
+description = No constraints, thus latest version of dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -50,4 +50,4 @@ deps=
     pytest>=8.0
 
 [testenv:latest]
-description = No constraints, thus latest version of dependencies
+description = Latest versions of dependencies within the project's declared constraints


### PR DESCRIPTION
I mentioned this before but I missed that in the latest review.

Latest crawl4ai is 0.7.2, thus 0.72 was probably a typo. On top of that, as discussed before, the correct place to fix this must be in the package definition in pyproject.toml, not in tox setup. Forcing tox setup makes the test to succeed, but anyone installing the package would go with the wrong version. The goal is not to force the test to succeed, but for the test to verify that the installation succeed.