### PR TITLE
Instruction to match all playwright components

### DIFF
--- a/docs/source/misc/INSTALL.rst
+++ b/docs/source/misc/INSTALL.rst
@@ -97,6 +97,8 @@ drivers that will be used to control this process. To do so, in your active cond
 .. code-block:: shell
 
     playwright install
+    rebrowser_playwright install
+    patchright install
 
 This will download all required browser drivers. You only need to perform this step once
 (i.e. during initial installation). If you see any warning messages about missing libraries,


### PR DESCRIPTION
Working with an auxiliary dev environment, I was getting an error due to mismatch of chromium versions. Sounds like we have to update all components to match the versions.