### PR TITLE
README also triggers checking documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,10 @@ name: Release Documentation
 permissions:
   contents: write
 
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - compass/**
       - docs/**
+      - README.rst
       - .github/workflows/docs.yml
       - pyproject.toml
       - pixi.lock
@@ -16,6 +17,7 @@ on:
     paths:
       - compass/**
       - docs/**
+      - README.rst
       - .github/workflows/docs.yml
       - pyproject.toml
       - pixi.lock


### PR DESCRIPTION
We missed an error introduced on #431 since it only touched README.rst, thus didn't trigger the check.

https://github.com/NatLabRockies/COMPASS/actions/runs/26480783979/job/77977326494#step:4:688