### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -50,8 +50,9 @@ jobs:
       with:
         pixi-version: v0.68.1
         locked: true
-        cache: false  # Don;t use cache because we want the newest version of the tool to be built and distributed (specifically the new version tag)
-        cache-write: false
+        # Don't use cache on release because we want the newest version of the tool to be built and distributed (specifically the new version tag)
+        cache: ${{ github.event_name != 'release' }}
+        cache-write: ${{ github.event_name != 'release' && github.ref == 'refs/heads/main' }}
         environments: pbuild
 
     - name: Clean README

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -50,8 +50,8 @@ jobs:
       with:
         pixi-version: v0.68.1
         locked: true
-        cache: true
-        cache-write: ${{ github.event_name != 'release' && github.ref == 'refs/heads/main' }}
+        cache: false  # Don;t use cache because we want the newest version of the tool to be built and distributed (specifically the new version tag)
+        cache-write: false
         environments: pbuild
 
     - name: Clean README


### PR DESCRIPTION
Can't use pixi cache for build action since we want the new version tags