### PR TITLE
Jurisdiction in prompt as a template input

### DIFF
--- a/compass/extraction/apply.py
+++ b/compass/extraction/apply.py
@@ -410,7 +410,9 @@ async def _extract_with_ngram_check(
     return doc
 
 
-async def extract_ordinance_values(doc, parser, text_key, out_key):
+async def extract_ordinance_values(
+    doc, parser, text_key, out_key, jurisdiction
+):
     """Extract ordinance values for a single document
 
     Document must be known to contain ordinance text.
@@ -434,6 +436,11 @@ async def extract_ordinance_values(doc, parser, text_key, out_key):
     out_key : str
         Name of the key under which extracted ordinances should be
         stored.
+    jurisdiction : Jurisdiction
+        Jurisdiction object corresponding to the document being parsed.
+        This is passed to the parser in case the system prompt needs any
+        information about the jurisdiction to successfully extract
+        values from the text.
 
     Returns
     -------
@@ -455,7 +462,9 @@ async def extract_ordinance_values(doc, parser, text_key, out_key):
         warn(msg, COMPASSWarning)
         return doc
 
-    doc.attrs[out_key] = await parser.parse(doc.attrs[text_key])
+    doc.attrs[out_key] = await parser.parse(
+        doc.attrs[text_key], jurisdiction=jurisdiction
+    )
     return doc
 
 

--- a/compass/extraction/small_wind/parse.py
+++ b/compass/extraction/small_wind/parse.py
@@ -256,7 +256,7 @@ class StructuredSmallWindOrdinanceParser(StructuredSmallWindParser):
     TASK_ID = LLMUsageCategory.ORDINANCE_VALUE_EXTRACTION
     """Identifier for this parser's specific LLM task category"""
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract structure ordinance data
 
         Parameters
@@ -266,6 +266,11 @@ class StructuredSmallWindOrdinanceParser(StructuredSmallWindParser):
             or more features (property lines, structure, roads, etc.).
             Text can also contain other supported regulations (noise,
             shadow-flicker, etc,) which will be extracted as well.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -278,20 +283,21 @@ class StructuredSmallWindOrdinanceParser(StructuredSmallWindParser):
         if not wes_type:
             return None
 
-        outer_task_name = asyncio.current_task().get_name()
         num_to_process = (
             len(SmallWindSetbackFeatures.DEFAULT_FEATURE_DESCRIPTIONS)
             + len(EXTRA_NUMERICAL_RESTRICTIONS)
             + len(EXTRA_QUALITATIVE_RESTRICTIONS)
         )
-        with COMPASS_PB.jurisdiction_sub_prog_bar(outer_task_name) as sub_pb:
+        with COMPASS_PB.jurisdiction_sub_prog_bar(
+            jurisdiction.full_name
+        ) as sub_pb:
             task_id = sub_pb.add_task(
                 "Extracting ordinance values...",
                 total=num_to_process,
                 just_parsed="",
             )
             outputs = await self._parse_all_restrictions_with_pb(
-                sub_pb, task_id, text, wes_type, outer_task_name
+                sub_pb, task_id, text, wes_type, jurisdiction.full_name
             )
             sub_pb.update(task_id, completed=num_to_process)
             await asyncio.sleep(1)
@@ -609,7 +615,7 @@ class StructuredSmallWindPermittedUseDistrictsParser(
         },
     ]
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract permitted use districts data
 
         Parameters
@@ -617,6 +623,11 @@ class StructuredSmallWindPermittedUseDistrictsParser(
         text : str
             Permitted use districts text which may or may not contain
             information about allowed uses in one or more districts.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -629,8 +640,9 @@ class StructuredSmallWindPermittedUseDistrictsParser(
         if not wes_type:
             return None
 
-        outer_task_name = asyncio.current_task().get_name()
-        with COMPASS_PB.jurisdiction_sub_prog_bar(outer_task_name) as sub_pb:
+        with COMPASS_PB.jurisdiction_sub_prog_bar(
+            jurisdiction.full_name
+        ) as sub_pb:
             task_id = sub_pb.add_task(
                 "Extracting permitted uses...",
                 total=len(self._USE_TYPES),
@@ -645,7 +657,7 @@ class StructuredSmallWindPermittedUseDistrictsParser(
                         wes_type,
                         **use_type_kwargs,
                     ),
-                    name=outer_task_name,
+                    name=jurisdiction.full_name,
                 )
                 for use_type_kwargs in self._USE_TYPES
             ]

--- a/compass/extraction/solar/parse.py
+++ b/compass/extraction/solar/parse.py
@@ -203,7 +203,7 @@ class StructuredSolarOrdinanceParser(StructuredSolarParser):
     TASK_ID = LLMUsageCategory.ORDINANCE_VALUE_EXTRACTION
     """Identifier for this parser's specific LLM task category"""
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract structure ordinance data
 
         Parameters
@@ -213,6 +213,11 @@ class StructuredSolarOrdinanceParser(StructuredSolarParser):
             or more features (property lines, structure, roads, etc.).
             Text can also contain other supported regulations (noise,
             shadow-flicker, etc,) which will be extracted as well.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -225,20 +230,21 @@ class StructuredSolarOrdinanceParser(StructuredSolarParser):
         if not largest_sef_type:
             return None
 
-        outer_task_name = asyncio.current_task().get_name()
         num_to_process = (
             len(SetbackFeatures.DEFAULT_FEATURE_DESCRIPTIONS)
             + len(EXTRA_NUMERICAL_RESTRICTIONS)
             + len(EXTRA_QUALITATIVE_RESTRICTIONS)
         )
-        with COMPASS_PB.jurisdiction_sub_prog_bar(outer_task_name) as sub_pb:
+        with COMPASS_PB.jurisdiction_sub_prog_bar(
+            jurisdiction.full_name
+        ) as sub_pb:
             task_id = sub_pb.add_task(
                 "Extracting ordinance values...",
                 total=num_to_process,
                 just_parsed="",
             )
             outputs = await self._parse_all_restrictions_with_pb(
-                sub_pb, task_id, text, largest_sef_type, outer_task_name
+                sub_pb, task_id, text, largest_sef_type, jurisdiction.full_name
             )
             sub_pb.update(task_id, completed=num_to_process)
             await asyncio.sleep(1)
@@ -570,7 +576,7 @@ class StructuredSolarPermittedUseDistrictsParser(StructuredSolarParser):
         },
     ]
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract permitted use districts data
 
         Parameters
@@ -578,6 +584,11 @@ class StructuredSolarPermittedUseDistrictsParser(StructuredSolarParser):
         text : str
             Permitted use districts text which may or may not contain
             information about allowed uses in one or more districts.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -590,8 +601,9 @@ class StructuredSolarPermittedUseDistrictsParser(StructuredSolarParser):
         if not largest_sef_type:
             return None
 
-        loc = asyncio.current_task().get_name()
-        with COMPASS_PB.jurisdiction_sub_prog_bar(loc) as sub_pb:
+        with COMPASS_PB.jurisdiction_sub_prog_bar(
+            jurisdiction.full_name
+        ) as sub_pb:
             task_id = sub_pb.add_task(
                 "Extracting permitted uses...",
                 total=len(self._USE_TYPES),
@@ -606,7 +618,7 @@ class StructuredSolarPermittedUseDistrictsParser(StructuredSolarParser):
                         largest_sef_type,
                         **use_type_kwargs,
                     ),
-                    name=loc,
+                    name=jurisdiction.full_name,
                 )
                 for use_type_kwargs in self._USE_TYPES
             ]

--- a/compass/extraction/wind/parse.py
+++ b/compass/extraction/wind/parse.py
@@ -193,7 +193,7 @@ class StructuredWindOrdinanceParser(StructuredWindParser):
     TASK_ID = LLMUsageCategory.ORDINANCE_VALUE_EXTRACTION
     """Identifier for this parser's specific LLM task category"""
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract structure ordinance data
 
         Parameters
@@ -203,6 +203,11 @@ class StructuredWindOrdinanceParser(StructuredWindParser):
             or more features (property lines, structure, roads, etc.).
             Text can also contain other supported regulations (noise,
             shadow-flicker, etc,) which will be extracted as well.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -215,20 +220,21 @@ class StructuredWindOrdinanceParser(StructuredWindParser):
         if not largest_wes_type:
             return None
 
-        outer_task_name = asyncio.current_task().get_name()
         num_to_process = (
             len(SetbackFeatures.DEFAULT_FEATURE_DESCRIPTIONS)
             + len(EXTRA_NUMERICAL_RESTRICTIONS)
             + len(EXTRA_QUALITATIVE_RESTRICTIONS)
         )
-        with COMPASS_PB.jurisdiction_sub_prog_bar(outer_task_name) as sub_pb:
+        with COMPASS_PB.jurisdiction_sub_prog_bar(
+            jurisdiction.full_name
+        ) as sub_pb:
             task_id = sub_pb.add_task(
                 "Extracting ordinance values...",
                 total=num_to_process,
                 just_parsed="",
             )
             outputs = await self._parse_all_restrictions_with_pb(
-                sub_pb, task_id, text, largest_wes_type, outer_task_name
+                sub_pb, task_id, text, largest_wes_type, jurisdiction.full_name
             )
             sub_pb.update(task_id, completed=num_to_process)
             await asyncio.sleep(1)
@@ -574,7 +580,7 @@ class StructuredWindPermittedUseDistrictsParser(StructuredWindParser):
         },
     ]
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract permitted use districts data
 
         Parameters
@@ -582,6 +588,11 @@ class StructuredWindPermittedUseDistrictsParser(StructuredWindParser):
         text : str
             Permitted use districts text which may or may not contain
             information about allowed uses in one or more districts.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -594,8 +605,9 @@ class StructuredWindPermittedUseDistrictsParser(StructuredWindParser):
         if not largest_wes_type:
             return None
 
-        outer_task_name = asyncio.current_task().get_name()
-        with COMPASS_PB.jurisdiction_sub_prog_bar(outer_task_name) as sub_pb:
+        with COMPASS_PB.jurisdiction_sub_prog_bar(
+            jurisdiction.full_name
+        ) as sub_pb:
             task_id = sub_pb.add_task(
                 "Extracting permitted uses...",
                 total=len(self._USE_TYPES),
@@ -610,7 +622,7 @@ class StructuredWindPermittedUseDistrictsParser(StructuredWindParser):
                         largest_wes_type,
                         **use_type_kwargs,
                     ),
-                    name=outer_task_name,
+                    name=jurisdiction.full_name,
                 )
                 for use_type_kwargs in self._USE_TYPES
             ]

--- a/compass/plugin/one_shot/base.py
+++ b/compass/plugin/one_shot/base.py
@@ -121,9 +121,31 @@ def create_schema_based_one_shot_extraction_plugin(config, tech):  # noqa: C901
               for the structured data extraction step. If not provided,
               a default prompt will be used that instructs the LLM to
               extract structured data from the given document(s). You
-              may provide a custom system prompt if you want to provide
-              more specific instructions to the LLM for the structured
-              data extraction step.
+              may provide a custom system prompt if you want more
+              specific instructions for this extraction step. Custom
+              prompts may include the following jurisdiction
+              placeholders, which are populated from the active
+              `Jurisdiction` object:
+
+                - ``{jur_full_name}``: Full jurisdiction name.
+                - ``{jur_full_name_the_prefixed}``: Full jurisdiction
+                    name with a leading ``the`` when needed.
+                - ``{jur_type}``: Jurisdiction type.
+                - ``{jur_state}``: State name.
+                - ``{jur_county}``: County name, if available.
+                - ``{jur_subdivision_name}``: Subdivision or
+                    municipality name, if available.
+                - ``{jur_full_subdivision_phrase}``: Full subdivision
+                    phrase, if available.
+                - ``{jur_full_subdivision_phrase_the_prefixed}``:
+                    Full subdivision phrase with a leading ``the`` when
+                    needed.
+                - ``{jur_full_county_phrase}``: Full county phrase,
+                    if available.
+                - ``{jur_code}``: Jurisdiction code, if available.
+                - ``{jur_website_url}``: Official website URL, if
+                    available.
+
             - `doc_selection_method`: String defining the multi-doc
               selection option. Specifically, if multiple documents pass
               the filter, this method determines how the documents are

--- a/compass/plugin/one_shot/components.py
+++ b/compass/plugin/one_shot/components.py
@@ -361,17 +361,22 @@ class SchemaOrdinanceParser(SchemaOutputLLMCaller, BaseParser):
             todays_date=todays_date,
             jur_type=jurisdiction.type,
             jur_state=jurisdiction.state,
-            jur_county=jurisdiction.county,
-            jur_subdivision_name=jurisdiction.subdivision_name,
-            jur_code=jurisdiction.code,
-            jur_website_url=jurisdiction.website_url,
+            jur_county=jurisdiction.county or "Unknown",
+            jur_subdivision_name=jurisdiction.subdivision_name or "Unknown",
+            jur_code=jurisdiction.code or "unknown",
+            jur_website_url=jurisdiction.website_url or "unknown",
             jur_full_name=jurisdiction.full_name,
             jur_full_name_the_prefixed=jurisdiction.full_name_the_prefixed,
-            jur_full_subdivision_phrase=jurisdiction.full_subdivision_phrase,
+            jur_full_subdivision_phrase=(
+                jurisdiction.full_subdivision_phrase or "unknown subdivision"
+            ),
             jur_full_subdivision_phrase_the_prefixed=(
                 jurisdiction.full_subdivision_phrase_the_prefixed
+                or "the unknown subdivision"
             ),
-            jur_full_county_phrase=jurisdiction.full_county_phrase,
+            jur_full_county_phrase=(
+                jurisdiction.full_county_phrase or "Unknown County"
+            ),
         )
 
         main_prompt = _DATA_PARSER_MAIN_PROMPT.format(desc=desc, text=text)

--- a/compass/plugin/one_shot/components.py
+++ b/compass/plugin/one_shot/components.py
@@ -324,7 +324,7 @@ class SchemaOrdinanceParser(SchemaOutputLLMCaller, BaseParser):
         """set: **Lowercase** feature names of qualitative features"""
         raise NotImplementedError
 
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract structured data
 
         Parameters
@@ -332,6 +332,11 @@ class SchemaOrdinanceParser(SchemaOutputLLMCaller, BaseParser):
         text : str
             Text which may or may not contain information relevant to
             the current extraction.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -351,7 +356,22 @@ class SchemaOrdinanceParser(SchemaOutputLLMCaller, BaseParser):
             f"{self.SYSTEM_PROMPT}\n\n{_DATA_PARSER_ADDITIONAL_CONTEXT}"
         )
         sys_prompt = sys_prompt.format(
-            desc=desc, schema=self.SCHEMA, todays_date=todays_date
+            desc=desc,
+            schema=self.SCHEMA,
+            todays_date=todays_date,
+            jur_type=jurisdiction.type,
+            jur_state=jurisdiction.state,
+            jur_county=jurisdiction.county,
+            jur_subdivision_name=jurisdiction.subdivision_name,
+            jur_code=jurisdiction.code,
+            jur_website_url=jurisdiction.website_url,
+            jur_full_name=jurisdiction.full_name,
+            jur_full_name_the_prefixed=jurisdiction.full_name_the_prefixed,
+            jur_full_subdivision_phrase=jurisdiction.full_subdivision_phrase,
+            jur_full_subdivision_phrase_the_prefixed=(
+                jurisdiction.full_subdivision_phrase_the_prefixed
+            ),
+            jur_full_county_phrase=jurisdiction.full_county_phrase,
         )
 
         main_prompt = _DATA_PARSER_MAIN_PROMPT.format(desc=desc, text=text)

--- a/compass/plugin/ordinance.py
+++ b/compass/plugin/ordinance.py
@@ -177,7 +177,7 @@ class BaseParser(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def parse(self, text):
+    async def parse(self, text, jurisdiction):
         """Parse text and extract structured data
 
         Parameters
@@ -185,6 +185,11 @@ class BaseParser(ABC):
         text : str
             Text which may or may not contain information relevant to
             the current extraction.
+        jurisdiction : Jurisdiction
+            Jurisdiction object corresponding to the document being
+            parsed. This is passed in case the system prompt needs any
+            information about the jurisdiction to successfully extract
+            values from the text.
 
         Returns
         -------
@@ -723,6 +728,7 @@ class OrdinanceExtractionPlugin(FilteredExtractionPlugin):
             parser,
             text_key=parser_class.IN_LABEL,
             out_key=parser_class.OUT_LABEL,
+            jurisdiction=self.jurisdiction,
         )
 
     @classmethod

--- a/examples/parse_existing_docs/code/parse_pdf.py
+++ b/examples/parse_existing_docs/code/parse_pdf.py
@@ -25,6 +25,7 @@ from compass.extraction.apply import (
     check_for_relevant_text,
     extract_relevant_text_with_llm,
 )
+from compass.utilities.jurisdictions import Jurisdiction
 from compass.utilities.logs import AddLocationFilter
 from compass.utilities.enums import LLMTasks
 
@@ -99,6 +100,9 @@ async def _extract_ordinances(doc, model_configs):
             ),
             text_key=ord_text_key,
             out_key=StructuredSolarOrdinanceParser.OUT_LABEL,
+            jurisdiction=Jurisdiction(
+                "county", county="Decatur", state="Indiana"
+            ),
         )
 
 


### PR DESCRIPTION
Allow one-shot plugins to use jurisdiction name placeholders in their system prompt to make it jurisdiction-specific. This is likely  a niche use-case but easy to support and will be helpful for some water rights documents.