### PR TITLE
Duplicate from different engines

### DIFF
--- a/compass/web/search.py
+++ b/compass/web/search.py
@@ -215,7 +215,13 @@ def _apply_blacklist_filters(results, url_blacklist, url_whitelist):
 
 
 def _apply_duplicate_filters(results):
-    """Mark duplicate rows by URL, across all search engines"""
+    """Mark duplicate rows by URL, across all search engines
+
+    Winner selection follows the priority encoded in
+    :func:`_link_sort_key`, so the engine listed first in the user
+    config only wins among entries that are otherwise tied (same
+    ``query_rank`` and ``query_index``).
+    """
     winners = {}
     for entry in _active_results_sorted(results):
         key = entry["url"]
@@ -267,7 +273,7 @@ def _link_sort_key(entry):
         entry["query_rank"],
         -duplicate_count,
         entry["query_index"],
-        entry["search_engine"],
+        entry["se_order"],
         entry["_order"],
     )
 

--- a/compass/web/search.py
+++ b/compass/web/search.py
@@ -215,10 +215,10 @@ def _apply_blacklist_filters(results, url_blacklist, url_whitelist):
 
 
 def _apply_duplicate_filters(results):
-    """Mark duplicate rows per search engine and URL"""
+    """Mark duplicate rows by URL, across all search engines"""
     winners = {}
     for entry in _active_results_sorted(results):
-        key = (entry["search_engine"], entry["url"])
+        key = entry["url"]
         winner = winners.get(key)
         if winner is None:
             winners[key] = entry

--- a/tests/python/unit/web/test_web_search.py
+++ b/tests/python/unit/web/test_web_search.py
@@ -79,14 +79,19 @@ def test_apply_duplicate_filters_keeps_best_and_tracks_duplicates():
 
 
 def test_apply_duplicate_filters_collapses_across_search_engines():
-    """Same URL from different engines should be marked duplicate"""
+    """Same URL from different engines should be marked duplicate
+
+    When ``query_rank`` and ``query_index`` tie, the entry from the
+    search engine listed first in the config (lower ``se_order``)
+    wins.
+    """
     results = [
         {
             "url": "https://example.com/a.pdf",
             "query": "q1",
             "query_index": 0,
-            "se_order": 0,
-            "search_engine": "SerpAPIGoogleSearch",
+            "se_order": 1,
+            "search_engine": "TavilySearch",
             "query_rank": 1,
             "overall_rank": None,
             "filtered_reason": None,
@@ -96,9 +101,9 @@ def test_apply_duplicate_filters_collapses_across_search_engines():
             "url": "https://example.com/a.pdf",
             "query": "q1",
             "query_index": 0,
-            "se_order": 1,
-            "search_engine": "TavilySearch",
-            "query_rank": 2,
+            "se_order": 0,
+            "search_engine": "SerpAPIGoogleSearch",
+            "query_rank": 1,
             "overall_rank": None,
             "filtered_reason": None,
             "_order": 1,
@@ -107,16 +112,17 @@ def test_apply_duplicate_filters_collapses_across_search_engines():
 
     search_module._apply_duplicate_filters(results)
 
-    winner = results[0]
-    loser = results[1]
+    winner = results[1]
+    loser = results[0]
 
     assert winner["filtered_reason"] is None
+    assert winner["search_engine"] == "SerpAPIGoogleSearch"
     assert winner["duplicates"] == [
         {
             "url": "https://example.com/a.pdf",
             "query": "q1",
             "search_engine": "TavilySearch",
-            "query_rank": 2,
+            "query_rank": 1,
         }
     ]
     assert loser["filtered_reason"] == "duplicate"

--- a/tests/python/unit/web/test_web_search.py
+++ b/tests/python/unit/web/test_web_search.py
@@ -78,6 +78,50 @@ def test_apply_duplicate_filters_keeps_best_and_tracks_duplicates():
     assert loser["filtered_reason"] == "duplicate"
 
 
+def test_apply_duplicate_filters_collapses_across_search_engines():
+    """Same URL from different engines should be marked duplicate"""
+    results = [
+        {
+            "url": "https://example.com/a.pdf",
+            "query": "q1",
+            "query_index": 0,
+            "se_order": 0,
+            "search_engine": "SerpAPIGoogleSearch",
+            "query_rank": 1,
+            "overall_rank": None,
+            "filtered_reason": None,
+            "_order": 0,
+        },
+        {
+            "url": "https://example.com/a.pdf",
+            "query": "q1",
+            "query_index": 0,
+            "se_order": 1,
+            "search_engine": "TavilySearch",
+            "query_rank": 2,
+            "overall_rank": None,
+            "filtered_reason": None,
+            "_order": 1,
+        },
+    ]
+
+    search_module._apply_duplicate_filters(results)
+
+    winner = results[0]
+    loser = results[1]
+
+    assert winner["filtered_reason"] is None
+    assert winner["duplicates"] == [
+        {
+            "url": "https://example.com/a.pdf",
+            "query": "q1",
+            "search_engine": "TavilySearch",
+            "query_rank": 2,
+        }
+    ]
+    assert loser["filtered_reason"] == "duplicate"
+
+
 def test_apply_top_n_filters_assigns_overall_rank_and_beyond_top_n():
     """Assign overall rank and mark entries beyond requested top-N"""
     results = [

--- a/tests/python/unit/web/test_web_search.py
+++ b/tests/python/unit/web/test_web_search.py
@@ -91,7 +91,7 @@ def test_apply_duplicate_filters_collapses_across_search_engines():
             "query": "q1",
             "query_index": 0,
             "se_order": 1,
-            "search_engine": "TavilySearch",
+            "search_engine": "TestSearch",
             "query_rank": 1,
             "overall_rank": None,
             "filtered_reason": None,
@@ -121,7 +121,7 @@ def test_apply_duplicate_filters_collapses_across_search_engines():
         {
             "url": "https://example.com/a.pdf",
             "query": "q1",
-            "search_engine": "TavilySearch",
+            "search_engine": "TestSearch",
             "query_rank": 1,
         }
     ]


### PR DESCRIPTION
The criteria used to be (engine, url), but we actually want the same URL only once, and we should take advantage on the agreement between multiple engines.

In one extreme, if both engines give exact the same result, it won't affect the order, otherwise, it prioritize what distinct engines agree on.

This PR also fix a mistake in the search engine criteria. Originally it was ordering by the name of the engine, while now it is by the order it was defined in the config, i.e. first listed engine has priority.