### PR TITLE
Filtering out grokipedia

### DIFF
--- a/compass/data/domains.json5
+++ b/compass/data/domains.json5
@@ -13,6 +13,7 @@
         "carolinas-dash.org",
         "findlaw.com",
         "encodeplus.com",
+        "grokipedia.com",
     ],
     "whitelist": [
         // If any of these substrings are in the URL, it is always included regardless of blacklist status


### PR DESCRIPTION
This is unreliable information. It could be used to point sources of valid information, but it would require to verify the references, so it wouldn't be better than any searching engine.